### PR TITLE
core/state: Fix memory expansion bug by not copying clean objects

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -187,7 +187,7 @@ func (self *StateObject) Copy() *StateObject {
 	stateObject.codeHash = common.CopyBytes(self.codeHash)
 	stateObject.nonce = self.nonce
 	stateObject.trie = self.trie
-	stateObject.code = common.CopyBytes(self.code)
+	stateObject.code = self.code
 	stateObject.initCode = common.CopyBytes(self.initCode)
 	stateObject.storage = self.storage.Copy()
 	stateObject.remove = self.remove

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -324,7 +324,9 @@ func (self *StateDB) Copy() *StateDB {
 	state, _ := New(common.Hash{}, self.db)
 	state.trie = self.trie
 	for k, stateObject := range self.stateObjects {
-		state.stateObjects[k] = stateObject.Copy()
+		if stateObject.dirty {
+			state.stateObjects[k] = stateObject.Copy()
+		}
 	}
 
 	state.refund.Set(self.refund)
@@ -364,7 +366,6 @@ func (s *StateDB) IntermediateRoot() common.Hash {
 				stateObject.Update()
 				s.UpdateStateObject(stateObject)
 			}
-			stateObject.dirty = false
 		}
 	}
 	return s.trie.Hash()


### PR DESCRIPTION
cherry-picked from https://github.com/ethereum/go-ethereum/pull/3006/commits/62f86a7479f0c81f2f4baab69980ffc7625aeb5a

testing resync now