### PR TITLE
Update README with new build status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,13 @@ recommending actions that must be taken to help complete the migration.
           | Linux   | OSX | ARM | Windows | Tests
 ----------|---------|-----|-----|---------|------
 develop   | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Develop_BuildLinux)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Develop_BuildLinux) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Develop_BuildOSX)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Develop_BuildOSX) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Develop_BuildARM)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Develop_BuildARM) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Develop_BuildWindows)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Develop_BuildWindows) | (TBD)
-master    | (TBD) | (TBD) | (TBD) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_GoEthereumMaster_BuildWindows)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_GoEthereumMaster_BuildWindows) | (TBD)
+master    | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Master_BuildLinux)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Master_BuildLinux) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Master_BuildOsx)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Master_BuildOsx) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Master_BuildArm)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Master_BuildArm) | [![Build Status](http://build.ethereumclassic.org/app/rest/builds/buildType:(id:GoEthereumClassic_Master_BuildWindows)/statusIcon)](http://build.ethereumclassic.org/viewType.html?buildTypeId=GoEthereumClassic_Master_BuildWindows) | (TBD)
 
 [![API Reference](
 https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 )](https://godoc.org/github.com/ethereumproject/go-ethereum)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereumproject/go-ethereum?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [ ![Download](https://api.bintray.com/packages/ethereumproject/GoEthereumClassic/go-ethereum/images/download.svg) ](https://bintray.com/ethereumproject/GoEthereumClassic/go-ethereum/_latestVersion)
-
-## Automated development builds
-Build servers still need to be set up. If you are interested in managing a build server, please open an issue.
 
 ## Building the source
 


### PR DESCRIPTION
The builds are polling from Github on *master* and *develop*, once every 20 minutes.  Tests are being skipped at the moment.  Artifacts are being uploaded to [BinTray](https://bintray.com/ethereumproject/GoEthereumClassic/go-ethereuml).

Release tags are not being automatically built yet, that is in progress.