### PR TITLE
Ecip-1010 config

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -850,11 +850,13 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 		splitSetting := ""
 		for i := range c.Forks {
 			if c.Forks[i].NetworkSplit {
-				netsplitChoice = "resulted in a network split."
-				if c.Forks[i].Support {
-					splitSetting = "Geth is configured to use the Ethereum (%v) hard-fork blockchain!"
-				} else {
-					splitSetting = "Geth is configured to use the \x1b[32mEthereum (ETC) classic/original\x1b[39m blockchain!"
+				netsplitChoice = fmt.Sprintf("resulted in a network split (support: %t)", c.Forks[i].Support)
+				if c.Forks[i].Name == "ETF" {
+					if c.Forks[i].Support {
+						splitSetting = "Geth is configured to use the Ethereum hard-fork blockchain!"
+					} else {
+						splitSetting = "Geth is configured to use the \x1b[32mEthereum (ETC) classic/original\x1b[39m blockchain!"
+					}
 				}
 			} else {
 				netsplitChoice = ""

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -815,12 +815,8 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 				}
 			}
 			if c.Forks[i].Name == "Diehard" {
-				//TODO: Add support for Diehard in Testnet
 				c.Forks[i].Block = params.DiehardBlock
-			}
-			if c.Forks[i].Name == "Explosion" {
-				//TODO: Add support for Explosion in Testnet
-				c.Forks[i].Block = params.ExplosionBlock
+				c.Forks[i].Length = big.NewInt(0).Sub(params.ExplosionBlock, params.DiehardBlock)
 			}
 			if c.Forks[i].Name == "ETF" {
 				if ctx.GlobalBool(ETFChain.Name) {
@@ -837,7 +833,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 			for x := range c.Forks {
 				exists = exists || c.Forks[x].Name == fork.Name
 			}
-			if (!exists) {
+			if !exists {
 				glog.V(logger.Warn).Info(fmt.Sprintf("Enable new fork: %s", fork.Name))
 				c.Forks = append(c.Forks, fork)
 			}

--- a/core/config.go
+++ b/core/config.go
@@ -55,18 +55,21 @@ func (c *ChainConfig) IsHomestead(num *big.Int) bool {
 
 // IsDiehard returns whether num is greater than or equal to the Diehard block, but less than explosion.
 func (c *ChainConfig) IsDiehard(num *big.Int) bool {
-	if c.Fork("Diehard").Block == nil || num == nil {
+	fork := c.Fork("Diehard")
+	if fork.Block == nil || num == nil {
 		return false
 	}
-	return num.Cmp(c.Fork("Diehard").Block) >= 0 && num.Cmp(c.Fork("Explosion").Block) < 0
+	return num.Cmp(fork.Block) >= 0 && num.Cmp(big.NewInt(0).Add(fork.Block, fork.Length)) < 0
 }
 
 // IsExplosion returns whether num is either equal to the explosion block or greater.
 func (c *ChainConfig) IsExplosion(num *big.Int) bool {
-	if c.Fork("Explosion").Block == nil || num == nil {
+	fork := c.Fork("Diehard")
+	if fork.Block == nil || num == nil {
 		return false
 	}
-	return num.Cmp(c.Fork("Explosion").Block) >= 0
+	block := big.NewInt(0).Add(fork.Block, fork.Length)
+	return num.Cmp(block) >= 0
 }
 
 func (c *ChainConfig) Fork(name string) *Fork {

--- a/core/fork.go
+++ b/core/fork.go
@@ -66,18 +66,6 @@ func LoadForks() []*Fork {
 			Support:      true,
 		},
 		&Fork{
-			Name:         "Diehard",
-			Block:        big.NewInt(3000000),
-			NetworkSplit: false,
-			Support:      true,
-		},
-		&Fork{
-			Name:         "Explosion",
-			Block:        big.NewInt(5000000),
-			NetworkSplit: false,
-			Support:      true,
-		},
-		&Fork{
 			Name:         "ETF",
 			Block:        big.NewInt(1920000),
 			NetworkSplit: true,
@@ -88,6 +76,18 @@ func LoadForks() []*Fork {
 			OrigSplitHash: "94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f",
 			// ETF Block+1
 			ForkSplitHash: "4985f5ca3d2afbec36529aa96f74de3cc10a2a4a6c44f2157a57d2c6059a11bb",
+		},
+		&Fork{
+			Name:         "Diehard",
+			Block:        big.NewInt(3000000),
+			NetworkSplit: true,
+			Support:      true,
+		},
+		&Fork{
+			Name:         "Explosion",
+			Block:        big.NewInt(5000000),
+			NetworkSplit: false,
+			Support:      true,
 		},
 	}
 }

--- a/core/fork.go
+++ b/core/fork.go
@@ -17,6 +17,8 @@ type Fork struct {
 	// Block is the block number where the hard-fork commences on
 	// the Ethereum network.
 	Block *big.Int
+	// Length of fork, if limited
+	Length *big.Int
 	// SplitHash to derive BadHashes to assist in avoiding sync issues
 	// after network split.
 	OrigSplitHash string
@@ -80,13 +82,8 @@ func LoadForks() []*Fork {
 		&Fork{
 			Name:         "Diehard",
 			Block:        big.NewInt(3000000),
+			Length:       big.NewInt(2000000),
 			NetworkSplit: true,
-			Support:      true,
-		},
-		&Fork{
-			Name:         "Explosion",
-			Block:        big.NewInt(5000000),
-			NetworkSplit: false,
 			Support:      true,
 		},
 	}

--- a/core/fork.go
+++ b/core/fork.go
@@ -83,7 +83,7 @@ func LoadForks() []*Fork {
 			Name:         "Diehard",
 			Block:        big.NewInt(3000000),
 			Length:       big.NewInt(2000000),
-			NetworkSplit: true,
+			NetworkSplit: false,
 			Support:      true,
 		},
 	}


### PR DESCRIPTION
Fix #51

Updates existing chain config with new Diehard fork (if not configured). Also this config was split into two, which was semantically incorrect and resulting into double messaging in console log.

Fork info was improved somewhat, now it looks like this:
```
$./build/bin/geth --datadir /tmp/gethtest1
I1007 21:43:42.389565 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /tmp/gethtest1/chaindata
I1007 21:43:42.400629 cmd/utils/flags.go:846] --------------------------------------------------------------------------------------------------------------
I1007 21:43:42.400655 cmd/utils/flags.go:847] Loading blockchain: genesis block "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3".
I1007 21:43:42.400668 cmd/utils/flags.go:848] 3 blockchain hard-forks associated with this genesis block:
I1007 21:43:42.400692 cmd/utils/flags.go:864]  Homestead hard-fork at block 1150000
I1007 21:43:42.400712 cmd/utils/flags.go:864]  ETF hard-fork at block 1920000 resulted in a network split (support: false)
I1007 21:43:42.400726 cmd/utils/flags.go:864]  Diehard hard-fork at block 3000000
I1007 21:43:42.400734 cmd/utils/flags.go:866] Geth is configured to use the Ethereum (ETC) classic/original blockchain!
I1007 21:43:42.400744 cmd/utils/flags.go:867] --------------------------------------------------------------------------------------------------------------
```