### PR TITLE
Show Geth version during startup

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -851,6 +851,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 	if !ctx.GlobalBool(TestNetFlag.Name) && (genesis == nil || genesis.Hash() == common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")) {
 		separator := strings.Repeat("-", 110)
 		glog.V(logger.Warn).Info(separator)
+		glog.V(logger.Warn).Info(fmt.Sprintf("Starting Geth Classic \x1b[32m%s\x1b[39m", ctx.App.Version))
 		glog.V(logger.Warn).Info("Loading blockchain: \x1b[36mgenesis\x1b[39m block \"\x1b[36m0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3\x1b[39m\".")
 		glog.V(logger.Warn).Info(fmt.Sprintf("%v blockchain hard-forks associated with this genesis block:", len(c.Forks)))
 		netsplitChoice := ""


### PR DESCRIPTION
fix #62

```
I1017 15:10:43.639159 cmd/utils/flags.go:853] --------------------------------------------------------------------------------------------------------------
I1017 15:10:43.639185 cmd/utils/flags.go:854] Starting Geth Classic 3.0.0-stable-d76ad4eb
I1017 15:10:43.639194 cmd/utils/flags.go:855] Loading blockchain: genesis block "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3".
I1017 15:10:43.639211 cmd/utils/flags.go:856] 4 blockchain hard-forks associated with this genesis block:
I1017 15:10:43.639231 cmd/utils/flags.go:872]  Homestead hard-fork at block 1150000
I1017 15:10:43.639250 cmd/utils/flags.go:872]  ETF hard-fork at block 1920000 resulted in a network split (support: false)
I1017 15:10:43.639263 cmd/utils/flags.go:872]  GasReprice hard-fork at block 2500000
I1017 15:10:43.639276 cmd/utils/flags.go:872]  Diehard hard-fork at block 3000000
I1017 15:10:43.639284 cmd/utils/flags.go:874] Geth is configured to use the Ethereum (ETC) classic/original blockchain!
I1017 15:10:43.639293 cmd/utils/flags.go:875] --------------------------------------------------------------------------------------------------------------
```