### PR TITLE
roll back to go-1.6 for building on launchpad

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -283,7 +283,7 @@ func doDebianSource(cmdline []string) {
 	flag.CommandLine.Parse(cmdline)
 	*workdir = makeWorkdir(*workdir)
 	env := build.Env()
-	//maybeSkipArchive(env)
+	maybeSkipArchive(env)
 
 	// Skip import of key for now.  Build agents are persistent and already have keys imported
 	// Import the signing key.

--- a/build/ci.go
+++ b/build/ci.go
@@ -283,7 +283,7 @@ func doDebianSource(cmdline []string) {
 	flag.CommandLine.Parse(cmdline)
 	*workdir = makeWorkdir(*workdir)
 	env := build.Env()
-	maybeSkipArchive(env)
+	//maybeSkipArchive(env)
 
 	// Skip import of key for now.  Build agents are persistent and already have keys imported
 	// Import the signing key.
@@ -308,7 +308,7 @@ func doDebianSource(cmdline []string) {
 		changes := fmt.Sprintf("%s_%s_source.changes", meta.Name(), meta.VersionString())
 		changes = filepath.Join(*workdir, changes)
 		if *signer != "" {
-			build.MustRunCommand("debsign", changes)
+			build.MustRunCommand("debsign","-p gpg2", changes)
 		}
 		if *upload != "" {
 			build.MustRunCommand("dput", *upload, changes)

--- a/build/deb.control
+++ b/build/deb.control
@@ -2,7 +2,7 @@ Source: {{.Name}}
 Section: science
 Priority: extra
 Maintainer: {{.Author}}
-Build-Depends: debhelper (>= 8.0.0), golang-1.7
+Build-Depends: debhelper (>= 8.0.0), golang-1.6
 Standards-Version: 3.9.5
 Homepage: https://ethereumclassic.org
 Vcs-Git: git://github.com/ethereumproject/go-ethereum.git

--- a/build/deb.rules
+++ b/build/deb.rules
@@ -5,7 +5,7 @@
 export DH_VERBOSE=1
 
 override_dh_auto_build:
-	build/env.sh /usr/lib/go-1.7/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
+	build/env.sh /usr/lib/go-1.6/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 
 override_dh_auto_test:
 


### PR DESCRIPTION
go 1.7 is not available on some of our ubuntu distro targets, preventing the PPA from building the package.  Only 16.10 has go-1.7.