### PR TITLE
JSON-RPC: Block field receiptRoot renamed to receiptsRoot

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -821,7 +821,7 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 		"gasUsed":          rpc.NewHexNumber(b.GasUsed()),
 		"timestamp":        rpc.NewHexNumber(b.Time()),
 		"transactionsRoot": b.TxHash(),
-		"receiptRoot":      b.ReceiptHash(),
+		"receiptsRoot":     b.ReceiptHash(),
 	}
 
 	if inclTx {


### PR DESCRIPTION
According to specification https://github.com/ethereumproject/wiki/wiki/JSON-RPC#eth_getblockbyhash
json response with block must contains "receiptsRoot" field.

Ethereum already fixed it in https://github.com/ethereum/go-ethereum/pull/3088/commits/71e8ae01b84cdde56761436a52552a25b03d2a97 