### PR TITLE
common: Use a different default data directory. Fixes #100.

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -36,11 +36,11 @@ func DefaultDataDir() string {
 	home := HomeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "Ethereum")
+			return filepath.Join(home, "Library", "EthereumClassic")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			return filepath.Join(home, "AppData", "Roaming", "EthereumClassic")
 		} else {
-			return filepath.Join(home, ".ethereum")
+			return filepath.Join(home, ".ethereumClassic")
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v", ProtocolVersions, config.NetworkId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.ChainId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.ChainId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v", ProtocolVersions, config.NetworkId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {


### PR DESCRIPTION
I noticed this issue contains the label size/L. Does that mean this commit should have been on the larger size to address the issue?

I've tested this code on Ubuntu 16.04 and it creates the expected .ethereumClassic directory and syncs, but that label made me think I missed something huge.