### PR TITLE
eth: Show Chain Id in startup logs. Resolves #110

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -36,11 +36,11 @@ func DefaultDataDir() string {
 	home := HomeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "EthereumClassic")
+			return filepath.Join(home, "Library", "Ethereum")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "EthereumClassic")
+			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
 		} else {
-			return filepath.Join(home, ".ethereumClassic")
+			return filepath.Join(home, ".ethereum")
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -36,11 +36,11 @@ func DefaultDataDir() string {
 	home := HomeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "Ethereum")
+			return filepath.Join(home, "Library", "EthereumClassic")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			return filepath.Join(home, "AppData", "Roaming", "EthereumClassic")
 		} else {
-			return filepath.Join(home, ".ethereum")
+			return filepath.Join(home, ".ethereumClassic")
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v", ProtocolVersions, config.NetworkId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.ChainId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.ChainId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v", ProtocolVersions, config.NetworkId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {


### PR DESCRIPTION
@splix Alright let's just pretend that embarrassing commit history didn't just happen. Please advise if you see anything missing. Tested on Ubuntu 16.04:

Testnet:

I1227 21:45:20.300033 eth/backend.go:172] Protocol Versions: [63 62], Network Id: 2, **Chain Id: 62**

Mainnet:

I1227 21:45:47.135501 eth/backend.go:172] Protocol Versions: [63 62], Network Id: 1, **Chain Id: 61**