### PR TITLE
eth: Show Chain Id in startup logs. Resolves #110

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,7 +169,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if db, ok := dappDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/dapp/")
 	}
-	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v", ProtocolVersions, config.NetworkId)
+	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.ChainId)
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {


### PR DESCRIPTION
@splix Re-submitting (clean) PR, #113 may be closed in substitution of this one. 

Tested on Ubuntu 16.04:

Mainnet:

I1228 10:38:41.707743 eth/backend.go:172] Protocol Versions: [63 62], Network Id: 1, **Chain Id: 61**

Testnet:

I1228 10:40:16.704581 eth/backend.go:172] Protocol Versions: [63 62], Network Id: 2, **Chain Id: 62**
