### PR TITLE
WIP: set and possibly migrate default data directory to new location

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -29,20 +29,59 @@ const (
 	DefaultWSPort    = 8546        // Default TCP port for the websocket RPC server
 )
 
-// DefaultDataDir is the default data directory to use for the databases and other
-// persistence requirements.
-func DefaultDataDir() string {
+
+func defaultDataDirParent() string {
 	// Try to place the data folder in the user's home dir
 	home := HomeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "Ethereum")
+			return filepath.Join(home, "Library")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			return filepath.Join(home, "AppData", "Roaming")
 		} else {
-			return filepath.Join(home, ".ethereum")
+			return filepath.Join(home)
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later
 	return ""
+}
+
+func defaultClassicDataDir() string {
+	if runtime.GOOS == "darwin" {
+		return "EthereumClassic"
+	} else if runtime.GOOS == "windows" {
+		return "EthereumClassic"
+	} else {
+		return ".ethereum-classic"
+	}
+}
+
+func defaultUnclassicDataDir() string {
+	if runtime.GOOS == "darwin" {
+		return "Ethereum"
+	} else if runtime.GOOS == "windows" {
+		return "Ethereum"
+	} else {
+		return ".ethereum"
+	}
+}
+
+// DefaultDataDir is the default data directory to use for the databases and other
+// persistence requirements.
+func DefaultDataDir() string {
+	// If the parentDir (os-specific) is available, use that.
+	if parentDir := defaultDataDirParent(); parentDir != "" {
+		return filepath.Join(parentDir, defaultClassicDataDir())
+	} else {
+		return parentDir
+	}
+}
+
+// DefaultUnclassicDataDir is the default data directory to check for preexisting unclassic persisted data.
+func DefaultUnclassicDataDir() string {
+	if parentDir := defaultDataDirParent(); parentDir != "" {
+		return filepath.Join(parentDir, defaultUnclassicDataDir())
+	} else {
+		return parentDir
+	}
 }

--- a/core/config.go
+++ b/core/config.go
@@ -59,6 +59,14 @@ type BadHash struct {
 	Hash  common.Hash
 }
 
+// IsETF returns whether num is equal to the bailout fork.
+func (c *ChainConfig) IsETF(num *big.Int) bool {
+	if c.Fork("ETF").Block == nil || num == nil {
+		return false
+	}
+	return num.Cmp(c.Fork("ETF").Block) == 0
+}
+
 // IsHomestead returns whether num is either equal to the homestead block or greater.
 func (c *ChainConfig) IsHomestead(num *big.Int) bool {
 	if c.Fork("Homestead").Block == nil || num == nil {


### PR DESCRIPTION
Addresses #100.

I'm not completely sure if [my check for ETClassic blockchain](https://github.com/rotblauer/go-ethereum-1/blob/data-directory-rename/cmd/geth/flag.go#L639), which references [this](https://github.com/rotblauer/go-ethereum-1/blob/data-directory-rename/core/config.go#L63) is right... as always, eager for feedback 👍 

Further considerations: 
- it might be nice to give a bit more warning (or an option to opt-out) to users since it would be moving their data
- this approach relies on the chaindata dir to be called `chaindata`, which will intersect with @splix's comment about named subdirs for chains
- decide on a name along the lines of `EthereumClassic` (vs `ethereum-classic`, etc); have seen multiple "opinions"
- the `common/defaults.go` changes could be refactored, too