### PR TITLE
Use Version = "source" for non-release builds

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -43,7 +43,7 @@ import (
 
 // Version is the application revision identifier. It can be set with the linker
 // as in: go build -ldflags "-X main.Version="`git describe --tags`
-var Version = "unknown"
+var Version = "source"
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
I initially thought it was a bug when I saw `unknown` as the logged Geth version. There might be a better wording than my suggested "source"... open to improvements.

# #world'ssmallestPR