### PR TITLE
test: accounts watch file TravisCI for macOS

### DIFF
--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -106,31 +106,40 @@ func TestWatchNoDir(t *testing.T) {
 	// Create the directory and copy a key file into it.
 	os.MkdirAll(dir, 0700)
 	defer os.RemoveAll(dir)
+
 	file := filepath.Join(dir, "aaa")
 	data, err := ioutil.ReadFile(cachetestAccounts[0].File)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(file, data, 0666); err != nil {
+	ff, err := os.Create(file)
+	if err != nil {
 		t.Fatal(err)
 	}
+	f, err := os.OpenFile(ff.Name(), os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Write(data)
+	f.Close()
 
 	// am should see the account.
 	wantAccounts := []Account{cachetestAccounts[0]}
 	wantAccounts[0].File = file
-	var seen, got = make(map[time.Duration]bool), make(map[time.Duration][]Account)
-	for d := 4 * time.Second; d < 8 * time.Second; d *= 2 {
+	var seen, gotAccounts = make(map[time.Duration]bool), make(map[time.Duration][]Account)
+	for d := 200 * time.Second; d < 8*time.Second; d *= 2 {
 		list = am.Accounts()
 		seen[d] = false
 		if reflect.DeepEqual(list, wantAccounts) {
 			seen[d] = true
+		} else {
 		}
-		got[d] = list
+		gotAccounts[d] = list
 		time.Sleep(d)
 	}
 	for i, saw := range seen {
 		if !saw {
-			t.Errorf("\nat %v got  %v\nwant %v", i, got[i], wantAccounts)
+			t.Errorf("\nat %v got  %v\nwant %v", i, gotAccounts[i], wantAccounts)
 		}
 	}
 }

--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -118,14 +118,20 @@ func TestWatchNoDir(t *testing.T) {
 	// am should see the account.
 	wantAccounts := []Account{cachetestAccounts[0]}
 	wantAccounts[0].File = file
-	for d := 200 * time.Millisecond; d < 8*time.Second; d *= 2 {
+	seen := make(map[time.Duration]bool)
+	for d := 400 * time.Millisecond; d < 8 * time.Second; d *= 2 {
 		list = am.Accounts()
+		seen[d] = false
 		if reflect.DeepEqual(list, wantAccounts) {
-			return
+			seen[d] = true
 		}
 		time.Sleep(d)
 	}
-	t.Errorf("\ngot  %v\nwant %v", list, wantAccounts)
+	for _, saw := range seen {
+		if !saw {
+			t.Errorf("\ngot  %v\nwant %v, with: %v", list, wantAccounts, seen)
+		}
+	}
 }
 
 func TestCacheInitialReload(t *testing.T) {

--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -118,18 +118,19 @@ func TestWatchNoDir(t *testing.T) {
 	// am should see the account.
 	wantAccounts := []Account{cachetestAccounts[0]}
 	wantAccounts[0].File = file
-	seen := make(map[time.Duration]bool)
-	for d := 400 * time.Millisecond; d < 8 * time.Second; d *= 2 {
+	var seen, got = make(map[time.Duration]bool), make(map[time.Duration][]Account)
+	for d := 1 * time.Second; d < 8 * time.Second; d *= 2 {
 		list = am.Accounts()
 		seen[d] = false
 		if reflect.DeepEqual(list, wantAccounts) {
 			seen[d] = true
+			got[d] = list
 		}
 		time.Sleep(d)
 	}
-	for _, saw := range seen {
+	for i, saw := range seen {
 		if !saw {
-			t.Errorf("\ngot  %v\nwant %v, with: %v", list, wantAccounts, seen)
+			t.Errorf("\nat %v got  %v\nwant %v", i, got[i], wantAccounts)
 		}
 	}
 }

--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -119,13 +119,13 @@ func TestWatchNoDir(t *testing.T) {
 	wantAccounts := []Account{cachetestAccounts[0]}
 	wantAccounts[0].File = file
 	var seen, got = make(map[time.Duration]bool), make(map[time.Duration][]Account)
-	for d := 2 * time.Second; d < 8 * time.Second; d *= 2 {
+	for d := 4 * time.Second; d < 8 * time.Second; d *= 2 {
 		list = am.Accounts()
 		seen[d] = false
 		if reflect.DeepEqual(list, wantAccounts) {
 			seen[d] = true
-			got[d] = list
 		}
+		got[d] = list
 		time.Sleep(d)
 	}
 	for i, saw := range seen {

--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -119,7 +119,7 @@ func TestWatchNoDir(t *testing.T) {
 	wantAccounts := []Account{cachetestAccounts[0]}
 	wantAccounts[0].File = file
 	var seen, got = make(map[time.Duration]bool), make(map[time.Duration][]Account)
-	for d := 1 * time.Second; d < 8 * time.Second; d *= 2 {
+	for d := 2 * time.Second; d < 8 * time.Second; d *= 2 {
 		list = am.Accounts()
 		seen[d] = false
 		if reflect.DeepEqual(list, wantAccounts) {

--- a/accounts/cache_test.go
+++ b/accounts/cache_test.go
@@ -116,12 +116,11 @@ func TestWatchNoDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f, err := os.OpenFile(ff.Name(), os.O_RDWR, 0666)
+	_, err = ff.Write(data)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Write(data)
-	f.Close()
+	ff.Close()
 
 	// am should see the account.
 	wantAccounts := []Account{cachetestAccounts[0]}


### PR DESCRIPTION
problem: TravisCI test _accounts/cache_test.go_: `TestWatchNoDir()` fails for macOS (#194)
possible solution: increase sleep and more verbose logging

other problem: can't recreate locally so I'll be keeping an eye on this CI
 