### PR TITLE
Remove 'sync busy' from standard logging

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -299,7 +299,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 		return true
 
 	case errBusy:
-		log.Print("sync busy")
+		glog.V(logger.Debug).Info("sync busy")
 
 	case errTimeout, errBadPeer, errStallingPeer, errEmptyHashSet,
 		errEmptyHeaderSet, errPeersUnavailable, errTooOld,


### PR DESCRIPTION
It is annoying and misleading. Blame @sjmackenzie for the good idea.  😉 👍