### PR TITLE
Use --lower-case-concatenated commands

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -51,14 +51,16 @@ if already existing.
 		`,
 	}
 	upgradedbCommand = cli.Command{
-		Action: upgradeDB,
-		Name:   "upgradedb",
-		Usage:  "upgrade chainblock database",
+		Action:  upgradeDB,
+		Name:    "upgrade-db",
+		Aliases: []string{"upgradedb"},
+		Usage:   "upgrade chainblock database",
 	}
 	removedbCommand = cli.Command{
-		Action: removeDB,
-		Name:   "removedb",
-		Usage:  "Remove blockchain and state databases",
+		Action:  removeDB,
+		Name:    "remove-db",
+		Aliases: []string{"removedb"},
+		Usage:   "Remove blockchain and state databases",
 	}
 	dumpCommand = cli.Command{
 		Action: dump,

--- a/cmd/geth/chainconfig.bats
+++ b/cmd/geth/chainconfig.bats
@@ -10,11 +10,11 @@ teardown() {
 	rm -fr $DATA_DIR
 }
 
-## dumpChainConfig JSON 
+## dump-chain-config JSON 
 
 # Test dumping chain configuration to JSON file.
 @test "chainconfig default dump" {
-	run $GETH_CMD --datadir $DATA_DIR --maxpeers 0 dumpChainConfig $DATA_DIR/dump.json
+	run $GETH_CMD --datadir $DATA_DIR --maxpeers 0 dump-chain-config $DATA_DIR/dump.json
 	echo "$output"
 
 	[ "$status" -eq 0 ]
@@ -28,7 +28,7 @@ teardown() {
 }
 
 @test "chainconfig testnet dump" {
-	run $GETH_CMD --datadir $DATA_DIR --testnet dumpChainConfig $DATA_DIR/dump.json
+	run $GETH_CMD --datadir $DATA_DIR --testnet dump-chain-config $DATA_DIR/dump.json
 	echo "$output"
 
 	[ "$status" -eq 0 ]
@@ -41,7 +41,7 @@ teardown() {
 }
 
 @test "chainconfig customnet dump" {
-	run $GETH_CMD --datadir $DATA_DIR --chain kittyCoin dumpChainConfig $DATA_DIR/dump.json
+	run $GETH_CMD --datadir $DATA_DIR --chain kittyCoin dump-chain-config $DATA_DIR/dump.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Wrote chain config file"* ]]
@@ -60,9 +60,9 @@ teardown() {
 	[[ "$output" == *"\"name\": \"kittyCoin\"," ]]
 }
 
-@test "chainconfig dumpChainConfig JSON dump is usable as external chainconfig" {
+@test "chainconfig dump-chain-config JSON dump is usable as external chainconfig" {
 # Same as 'chainconfig customnet dump'... higher complexity::more confidence
-	run $GETH_CMD --datadir $DATA_DIR --chain kittyCoin dumpChainConfig $DATA_DIR/dump.json
+	run $GETH_CMD --datadir $DATA_DIR --chain kittyCoin dump-chain-config $DATA_DIR/dump.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Wrote chain config file"* ]]

--- a/cmd/geth/cli.bats
+++ b/cmd/geth/cli.bats
@@ -67,6 +67,29 @@ teardown() {
 	[[ "$output" == *"USAGE"* ]]
 }
 
+@test "alias for snake-case-commands" {
+	old_command_names=(maxpeers nodiscover ipcdisable)
+	new_command_names=(max-peers no-discover ipc-disable)
+	
+	for var in "${old_command_names[@]}"
+	do
+		run $GETH_CMD --$var --datadir $DATA_DIR --exec 'exit' console
+		[ "$status" -eq 0 ]
+		[[ "$output" == *"Starting"* ]]
+		[[ "$output" == *"Blockchain DB Version: "* ]]
+		[[ "$output" == *"Starting Server"* ]]
+	done
+
+	for var in "${new_command_names[@]}"
+	do
+		run $GETH_CMD --$var --data-dir $DATA_DIR --exec 'exit' console
+		[ "$status" -eq 0 ]
+		[[ "$output" == *"Starting"* ]]
+		[[ "$output" == *"Blockchain DB Version: "* ]]
+		[[ "$output" == *"Starting Server"* ]]
+	done
+}
+
 # TODO
 # This doesn't pass, and that's an issue.
 # @test "displays help with valid command and invalid subcommand" {

--- a/cmd/geth/cli.bats
+++ b/cmd/geth/cli.bats
@@ -143,3 +143,4 @@ teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Alloted 17MB cache"* ]]
 }
+

--- a/cmd/geth/cli.bats
+++ b/cmd/geth/cli.bats
@@ -67,7 +67,7 @@ teardown() {
 	[[ "$output" == *"USAGE"* ]]
 }
 
-@test "aliases for directory flags" {
+@test "aliases for directory-flags" {
 	old_command_names=(datadir keystore docroot ipcpath)
 	new_command_names=(data-dir keystore doc-root ipc-path)
 
@@ -93,29 +93,29 @@ teardown() {
 	done
 }
 
-# @test "alias for snake-case-commands" {
-# 	old_command_names=(nodiscover ipcdisable)
-# 	new_command_names=(no-discover ipc-disable)
+@test "alias for hyphenated-commands" {
+	old_command_names=(nodiscover ipcdisable) # ... assuming that if two work, the rest will work.
+	new_command_names=(no-discover ipc-disable)
 	
-# 	for var in "${old_command_names[@]}"
-# 	do
-# 		# hardcode --datadir/--data-dir
-# 		run $GETH_CMD --datadir $DATA_DIR --$var --exec 'exit' console
-# 		[ "$status" -eq 0 ]
-# 		[[ "$output" == *"Starting"* ]]
-# 		[[ "$output" == *"Blockchain DB Version: "* ]]
-# 		[[ "$output" == *"Starting Server"* ]]
-# 	done
+	for var in "${old_command_names[@]}"
+	do
+		# hardcode --datadir/--data-dir
+		run $GETH_CMD --datadir $DATA_DIR --$var --exec 'exit' console
+		[ "$status" -eq 0 ]
+		[[ "$output" == *"Starting"* ]]
+		[[ "$output" == *"Blockchain DB Version: "* ]]
+		[[ "$output" == *"Starting Server"* ]]
+	done
 
-# 	for var in "${new_command_names[@]}"
-# 	do
-# 		run $GETH_CMD --data-dir $DATA_DIR --$var --exec 'exit' console
-# 		[ "$status" -eq 0 ]
-# 		[[ "$output" == *"Starting"* ]]
-# 		[[ "$output" == *"Blockchain DB Version: "* ]]
-# 		[[ "$output" == *"Starting Server"* ]]
-# 	done
-# }
+	for var in "${new_command_names[@]}"
+	do
+		run $GETH_CMD --data-dir $DATA_DIR --$var --exec 'exit' console
+		[ "$status" -eq 0 ]
+		[[ "$output" == *"Starting"* ]]
+		[[ "$output" == *"Blockchain DB Version: "* ]]
+		[[ "$output" == *"Starting Server"* ]]
+	done
+}
 
 # TODO
 # This doesn't pass, and that's an issue.

--- a/cmd/geth/cli.bats
+++ b/cmd/geth/cli.bats
@@ -67,13 +67,16 @@ teardown() {
 	[[ "$output" == *"USAGE"* ]]
 }
 
-@test "alias for snake-case-commands" {
-	old_command_names=(maxpeers nodiscover ipcdisable)
-	new_command_names=(max-peers no-discover ipc-disable)
-	
+@test "aliases for directory flags" {
+	old_command_names=(datadir keystore docroot ipcpath)
+	new_command_names=(data-dir keystore doc-root ipc-path)
+
 	for var in "${old_command_names[@]}"
 	do
-		run $GETH_CMD --$var --datadir $DATA_DIR --exec 'exit' console
+		# hardcode --datadir/--data-dir
+		run $GETH_CMD --$var $DATA_DIR/abc$var console
+		echo "$output"
+
 		[ "$status" -eq 0 ]
 		[[ "$output" == *"Starting"* ]]
 		[[ "$output" == *"Blockchain DB Version: "* ]]
@@ -82,13 +85,37 @@ teardown() {
 
 	for var in "${new_command_names[@]}"
 	do
-		run $GETH_CMD --$var --data-dir $DATA_DIR --exec 'exit' console
+		run $GETH_CMD --$var $DATA_DIR/abc$var console
 		[ "$status" -eq 0 ]
 		[[ "$output" == *"Starting"* ]]
 		[[ "$output" == *"Blockchain DB Version: "* ]]
 		[[ "$output" == *"Starting Server"* ]]
 	done
 }
+
+# @test "alias for snake-case-commands" {
+# 	old_command_names=(nodiscover ipcdisable)
+# 	new_command_names=(no-discover ipc-disable)
+	
+# 	for var in "${old_command_names[@]}"
+# 	do
+# 		# hardcode --datadir/--data-dir
+# 		run $GETH_CMD --datadir $DATA_DIR --$var --exec 'exit' console
+# 		[ "$status" -eq 0 ]
+# 		[[ "$output" == *"Starting"* ]]
+# 		[[ "$output" == *"Blockchain DB Version: "* ]]
+# 		[[ "$output" == *"Starting Server"* ]]
+# 	done
+
+# 	for var in "${new_command_names[@]}"
+# 	do
+# 		run $GETH_CMD --data-dir $DATA_DIR --$var --exec 'exit' console
+# 		[ "$status" -eq 0 ]
+# 		[[ "$output" == *"Starting"* ]]
+# 		[[ "$output" == *"Blockchain DB Version: "* ]]
+# 		[[ "$output" == *"Starting Server"* ]]
+# 	done
+# }
 
 # TODO
 # This doesn't pass, and that's an issue.

--- a/cmd/geth/cli.bats
+++ b/cmd/geth/cli.bats
@@ -67,63 +67,55 @@ teardown() {
 	[[ "$output" == *"USAGE"* ]]
 }
 
+# TODO
+# This doesn't pass, and that's an issue.
+# @test "displays help with valid command and invalid subcommand" {
+# 	# lisr
+# 	run $GETH_CMD account lisr
+# 	echo "$output"
+
+# 	[ "$status" -eq 3 ]
+# 	[[ "$output" == *"SUBCOMMANDS"* ]]
+# }
+
 @test "aliases for directory-flags" {
-	VAR_DIR=`mktemp -d`
+
+	# keystore not hyphenated
+	run $GETH_CMD --datadir $DATA_DIR --keystore $DATA_DIR/keyhere console
+	[ "$status" -eq 0 ]
+	[ -d $DATA_DIR/keyhere ]
+
+	# data-dir/datadir
+	run $GETH_CMD --datadir $DATA_DIR console
+	[ "$status" -eq 0 ]
+	[ -d $DATA_DIR ]
+
+	run $GETH_CMD --data-dir $DATA_DIR console
+	[ "$status" -eq 0 ]
+	[ -d $DATA_DIR ]
+
+	# # ipc-path/ipcpath
+	run $GETH_CMD --data-dir $DATA_DIR --ipc-path abc.ipc console
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"IPC endpoint opened: $DATA_DIR/mainnet/abc.ipc"* ]]
+
+	run $GETH_CMD --data-dir $DATA_DIR --ipcpath $DATA_DIR/mainnet/abc.ipc console
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"IPC endpoint opened: $DATA_DIR/mainnet/abc.ipc"* ]]
+
+	run $GETH_CMD --data-dir $DATA_DIR --ipc-path $DATA_DIR/mainnet/abc console
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"IPC endpoint opened: $DATA_DIR/mainnet/abc"* ]]
+
+	run $GETH_CMD --data-dir $DATA_DIR --ipcpath $DATA_DIR/mainnet/abc console
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"IPC endpoint opened: $DATA_DIR/mainnet/abc"* ]]
 	
-	old_command_names=(keystore docroot ipcpath)
-	new_command_names=(keystore doc-root ipc-path)
-	paths_args=($DATA_DIR/keyhere $VAR_DIR/docroothere $DATA_DIR/abc.ipc)
-	paths_types=(ddd none ff)
-
-	counter=0
-	for var in "${old_command_names[@]}"
-	do
-		# hardcode --datadir/--data-dir
-		run $GETH_CMD --datadir $DATA_DIR --$var "${paths_args[counter]}" console
-		echo "$output"
-
-		[ "$status" -eq 0 ]
-		[[ "$output" == *"Starting"* ]]
-		[[ "$output" == *"Blockchain DB Version: "* ]]
-		[[ "$output" == *"Starting Server"* ]]
-
-		if [[ "${paths_types[counter]}" == "ddd" ]]; then
-			[ -d "${paths_args[counter]}" ]
-		elif [[ "${paths_types[counter]}" == "ff" ]]; then
-			[ -f "${paths_args[counter]}" ]
-		#else
-			# flag not parsed
-		fi
-
-		((counter=counter+1))
-	done
-	counter=0
-	for var in "${new_command_names[@]}"
-	do
-		run $GETH_CMD --data-dir $DATA_DIR --$var "${paths_args[counter]}" console
-		echo "$output"
-		
-		[ "$status" -eq 0 ]
-		[[ "$output" == *"Starting"* ]]
-		[[ "$output" == *"Blockchain DB Version: "* ]]
-		[[ "$output" == *"Starting Server"* ]]
-
-		if [[ "${paths_types[counter]}" == "ddd" ]]; then
-			[ -d "${paths_args[counter]}" ]
-		elif [[ "${paths_types[counter]}" == "ff" ]]; then
-			[ -f "${paths_args[counter]}" ]
-		#else
-			# flag not parsed
-		fi
-
-		((counter=counter+1))
-	done
-
-	rm -rf $VAR_DIR
 }
 
+# ... assuming that if two work, the rest will work.
 @test "alias for hyphenated-commands" {
-	old_command_names=(nodiscover ipcdisable) # ... assuming that if two work, the rest will work.
+	old_command_names=(nodiscover ipcdisable) 
 	new_command_names=(no-discover ipc-disable)
 	
 	for var in "${old_command_names[@]}"
@@ -146,13 +138,8 @@ teardown() {
 	done
 }
 
-# TODO
-# This doesn't pass, and that's an issue.
-# @test "displays help with valid command and invalid subcommand" {
-# 	# lisr
-# 	run $GETH_CMD account lisr
-# 	echo "$output"
-
-# 	[ "$status" -eq 3 ]
-# 	[[ "$output" == *"SUBCOMMANDS"* ]]
-# }
+@test "int flags get parsed" {
+	run $GETH_CMD --data-dir $DATA_DIR --cache 17 console
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Alloted 17MB cache"* ]]
+}

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -201,7 +201,7 @@ func MakeBootstrapNodesFromContext(ctx *cli.Context) []*discover.Node {
 // MakeListenAddress creates a TCP listening address string from set command
 // line flags.
 func MakeListenAddress(ctx *cli.Context) string {
-	return fmt.Sprintf(":%d", ctx.GlobalInt(aliasableName(ListenPortFlag.Name, ctx)))
+	return fmt.Sprintf(":%d", ListenPortFlag.Value)
 }
 
 // MakeNAT creates a port mapper from set command line flags.
@@ -569,15 +569,15 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 		BootstrapNodes:  config.ParsedBootstrap,
 		ListenAddr:      MakeListenAddress(ctx),
 		NAT:             MakeNAT(ctx),
-		MaxPeers:        ctx.GlobalInt(aliasableName(MaxPeersFlag.Name, ctx)),
-		MaxPendingPeers: ctx.GlobalInt(aliasableName(MaxPendingPeersFlag.Name, ctx)),
+		MaxPeers:        MaxPeersFlag.Value,
+		MaxPendingPeers: MaxPendingPeersFlag.Value,
 		IPCPath:         MakeIPCPath(ctx),
 		HTTPHost:        MakeHTTPRpcHost(ctx),
-		HTTPPort:        ctx.GlobalInt(aliasableName(RPCPortFlag.Name, ctx)),
+		HTTPPort:        RPCPortFlag.Value,
 		HTTPCors:        ctx.GlobalString(aliasableName(RPCCORSDomainFlag.Name, ctx)),
 		HTTPModules:     MakeRPCModules(ctx.GlobalString(aliasableName(RPCApiFlag.Name, ctx))),
 		WSHost:          MakeWSRpcHost(ctx),
-		WSPort:          ctx.GlobalInt(aliasableName(WSPortFlag.Name, ctx)),
+		WSPort:          WSPortFlag.Value,
 		WSOrigins:       ctx.GlobalString(aliasableName(WSAllowedOriginsFlag.Name, ctx)),
 		WSModules:       MakeRPCModules(ctx.GlobalString(aliasableName(WSApiFlag.Name, ctx))),
 	}
@@ -588,22 +588,22 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 	ethConf := &eth.Config{
 		ChainConfig:             config.ChainConfig,
 		FastSync:                ctx.GlobalBool(aliasableName(FastSyncFlag.Name, ctx)),
-		BlockChainVersion:       ctx.GlobalInt(aliasableName(BlockchainVersionFlag.Name, ctx)),
-		DatabaseCache:           ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx)),
+		BlockChainVersion:       BlockchainVersionFlag.Value,
+		DatabaseCache:           CacheFlag.Value,
 		DatabaseHandles:         MakeDatabaseHandles(),
-		NetworkId:               ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)),
+		NetworkId:               NetworkIdFlag.Value,
 		AccountManager:          accman,
 		Etherbase:               MakeEtherbase(accman, ctx),
-		MinerThreads:            ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)),
+		MinerThreads:            MinerThreadsFlag.Value,
 		NatSpec:                 ctx.GlobalBool(aliasableName(NatspecEnabledFlag.Name, ctx)),
 		DocRoot:                 ctx.GlobalString(aliasableName(aliasableName(DocRootFlag.Name, ctx), ctx)),
 		GasPrice:                new(big.Int),
 		GpoMinGasPrice:          new(big.Int),
 		GpoMaxGasPrice:          new(big.Int),
-		GpoFullBlockRatio:       ctx.GlobalInt(aliasableName(GpoFullBlockRatioFlag.Name, ctx)),
-		GpobaseStepDown:         ctx.GlobalInt(aliasableName(GpobaseStepDownFlag.Name, ctx)),
-		GpobaseStepUp:           ctx.GlobalInt(aliasableName(GpobaseStepUpFlag.Name, ctx)),
-		GpobaseCorrectionFactor: ctx.GlobalInt(aliasableName(GpobaseCorrectionFactorFlag.Name, ctx)),
+		GpoFullBlockRatio:       GpoFullBlockRatioFlag.Value,
+		GpobaseStepDown:         GpobaseStepDownFlag.Value,
+		GpobaseStepUp:           GpobaseStepUpFlag.Value,
+		GpobaseCorrectionFactor: GpobaseCorrectionFactorFlag.Value,
 		SolcPath:                ctx.GlobalString(aliasableName(SolcPathFlag.Name, ctx)),
 		AutoDAG:                 ctx.GlobalBool(aliasableName(AutoDAGFlag.Name, ctx)) || ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)),
 	}
@@ -782,7 +782,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 func MakeChainDatabase(ctx *cli.Context) ethdb.Database {
 	var (
 		datadir = MustMakeChainDataDir(ctx)
-		cache   = ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx))
+		cache   = CacheFlag.Value
 		handles = MakeDatabaseHandles()
 	)
 

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -132,7 +132,7 @@ func getChainConfigNameFromContext(ctx *cli.Context) string {
 // if none (or the empty string) is specified.
 // --> <home>/<EthereumClassic>(defaulty) or --datadir
 func mustMakeDataDir(ctx *cli.Context) string {
-	if path := ctx.GlobalString(aliasableName(aliasableName(DataDirFlag.Name, ctx), ctx)); path != "" {
+	if path := ctx.GlobalString(aliasableName(DataDirFlag.Name, ctx)); path != "" {
 		return path
 	}
 	log.Fatal("Cannot determine data directory, please set manually (--datadir)")
@@ -152,7 +152,7 @@ func MakeIPCPath(ctx *cli.Context) string {
 	if ctx.GlobalBool(aliasableName(IPCDisabledFlag.Name, ctx)) {
 		return ""
 	}
-	return ctx.GlobalString(aliasableName(aliasableName(IPCPathFlag.Name, ctx), ctx))
+	return ctx.GlobalString(aliasableName(IPCPathFlag.Name, ctx))
 }
 
 // MakeNodeKey creates a node key from set command line flags, either loading it
@@ -596,7 +596,7 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 		Etherbase:               MakeEtherbase(accman, ctx),
 		MinerThreads:            ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)),
 		NatSpec:                 ctx.GlobalBool(aliasableName(NatspecEnabledFlag.Name, ctx)),
-		DocRoot:                 ctx.GlobalString(aliasableName(aliasableName(DocRootFlag.Name, ctx), ctx)),
+		DocRoot:                 ctx.GlobalString(aliasableName(DocRootFlag.Name, ctx)),
 		GasPrice:                new(big.Int),
 		GpoMinGasPrice:          new(big.Int),
 		GpoMaxGasPrice:          new(big.Int),

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -90,18 +90,18 @@ var reservedChainIDS = map[string]bool{
 // Disallowed words which conflict with in-use data files will log the problem and return "",
 // which cause an error.
 func getChainConfigIDFromContext(ctx *cli.Context) string {
-	chainFlagIsSet := ctx.GlobalIsSet(TestNetFlag.Name) || ctx.GlobalIsSet(ChainIDFlag.Name)
+	chainFlagIsSet := ctx.GlobalIsSet(aliasableName(TestNetFlag.Name, ctx)) || ctx.GlobalIsSet(aliasableName(ChainIDFlag.Name, ctx))
 	if chainFlagIsSet && currentChainID != "" {
 		panic("Flags --chainconfig and --chain are conflicting. Please use only one.")
 	}
 	if currentChainID != "" {
 		return currentChainID
 	}
-	if ctx.GlobalBool(TestNetFlag.Name) {
+	if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 		return core.DefaultTestnetChainConfigID
 	}
-	if ctx.GlobalIsSet(ChainIDFlag.Name) {
-		if id := ctx.GlobalString(ChainIDFlag.Name); id != "" {
+	if ctx.GlobalIsSet(aliasableName(ChainIDFlag.Name, ctx)) {
+		if id := ctx.GlobalString(aliasableName(ChainIDFlag.Name, ctx)); id != "" {
 			if reservedChainIDS[id] {
 				log.Fatal("Reserved words for --chain flag include: 'chaindata', 'dapp', 'keystore', 'nodekey', 'nodes'. Please use a different identifier.")
 				return ""
@@ -119,10 +119,10 @@ func getChainConfigIDFromContext(ctx *cli.Context) string {
 // If a custom net is in use, it echoes the name of the ChainConfigID.
 // It is intended to be a human-readable name for a chain configuration.
 func getChainConfigNameFromContext(ctx *cli.Context) string {
-	if ctx.GlobalBool(TestNetFlag.Name) {
+	if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 		return core.DefaultTestnetChainConfigName
 	}
-	if ctx.GlobalIsSet(ChainIDFlag.Name) {
+	if ctx.GlobalIsSet(aliasableName(ChainIDFlag.Name, ctx)) {
 		return getChainConfigIDFromContext(ctx) // shortcut
 	}
 	return core.DefaultChainConfigName
@@ -132,7 +132,7 @@ func getChainConfigNameFromContext(ctx *cli.Context) string {
 // if none (or the empty string) is specified.
 // --> <home>/<EthereumClassic>(defaulty) or --datadir
 func mustMakeDataDir(ctx *cli.Context) string {
-	if path := ctx.GlobalString(aliasableName(DataDirFlag.Name, ctx)); path != "" {
+	if path := ctx.GlobalString(aliasableName(aliasableName(DataDirFlag.Name, ctx), ctx)); path != "" {
 		return path
 	}
 	log.Fatal("Cannot determine data directory, please set manually (--datadir)")
@@ -149,10 +149,10 @@ func MustMakeChainDataDir(ctx *cli.Context) string {
 // MakeIPCPath creates an IPC path configuration from the set command line flags,
 // returning an empty string if IPC was explicitly disabled, or the set path.
 func MakeIPCPath(ctx *cli.Context) string {
-	if ctx.GlobalBool(IPCDisabledFlag.Name) {
+	if ctx.GlobalBool(aliasableName(IPCDisabledFlag.Name, ctx)) {
 		return ""
 	}
-	return ctx.GlobalString(aliasableName(IPCPathFlag.Name, ctx))
+	return ctx.GlobalString(aliasableName(aliasableName(IPCPathFlag.Name, ctx), ctx))
 }
 
 // MakeNodeKey creates a node key from set command line flags, either loading it
@@ -160,24 +160,24 @@ func MakeIPCPath(ctx *cli.Context) string {
 // method returns nil and an emphemeral key is to be generated.
 func MakeNodeKey(ctx *cli.Context) *ecdsa.PrivateKey {
 	var (
-		hex  = ctx.GlobalString(NodeKeyHexFlag.Name)
-		file = ctx.GlobalString(NodeKeyFileFlag.Name)
+		hex  = ctx.GlobalString(aliasableName(NodeKeyHexFlag.Name, ctx))
+		file = ctx.GlobalString(aliasableName(NodeKeyFileFlag.Name, ctx))
 
 		key *ecdsa.PrivateKey
 		err error
 	)
 	switch {
 	case file != "" && hex != "":
-		log.Fatalf("Options %q and %q are mutually exclusive", NodeKeyFileFlag.Name, NodeKeyHexFlag.Name)
+		log.Fatalf("Options %q and %q are mutually exclusive", aliasableName(NodeKeyFileFlag.Name, ctx), aliasableName(NodeKeyHexFlag.Name, ctx))
 
 	case file != "":
 		if key, err = crypto.LoadECDSA(file); err != nil {
-			log.Fatalf("Option %q: %v", NodeKeyFileFlag.Name, err)
+			log.Fatalf("Option %q: %v", aliasableName(NodeKeyFileFlag.Name, ctx), err)
 		}
 
 	case hex != "":
 		if key, err = crypto.HexToECDSA(hex); err != nil {
-			log.Fatalf("Option %q: %v", NodeKeyHexFlag.Name, err)
+			log.Fatalf("Option %q: %v", aliasableName(NodeKeyHexFlag.Name, ctx), err)
 		}
 	}
 	return key
@@ -187,28 +187,28 @@ func MakeNodeKey(ctx *cli.Context) *ecdsa.PrivateKey {
 // flags, reverting to pre-configured ones if none have been specified.
 func MakeBootstrapNodesFromContext(ctx *cli.Context) []*discover.Node {
 	// Return pre-configured nodes if none were manually requested
-	if !ctx.GlobalIsSet(BootnodesFlag.Name) {
+	if !ctx.GlobalIsSet(aliasableName(BootnodesFlag.Name, ctx)) {
 
 		// --testnet flag overrides --config flag
-		if ctx.GlobalBool(TestNetFlag.Name) {
+		if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 			return TestNetBootNodes
 		}
 		return HomesteadBootNodes
 	}
-	return core.ParseBootstrapNodeStrings(strings.Split(ctx.GlobalString(BootnodesFlag.Name), ","))
+	return core.ParseBootstrapNodeStrings(strings.Split(ctx.GlobalString(aliasableName(BootnodesFlag.Name, ctx)), ","))
 }
 
 // MakeListenAddress creates a TCP listening address string from set command
 // line flags.
 func MakeListenAddress(ctx *cli.Context) string {
-	return fmt.Sprintf(":%d", ctx.GlobalInt(ListenPortFlag.Name))
+	return fmt.Sprintf(":%d", ctx.GlobalInt(aliasableName(ListenPortFlag.Name, ctx)))
 }
 
 // MakeNAT creates a port mapper from set command line flags.
 func MakeNAT(ctx *cli.Context) nat.Interface {
-	natif, err := nat.Parse(ctx.GlobalString(NATFlag.Name))
+	natif, err := nat.Parse(ctx.GlobalString(aliasableName(NATFlag.Name, ctx)))
 	if err != nil {
-		log.Fatalf("Option %s: %v", NATFlag.Name, err)
+		log.Fatalf("Option %s: %v", aliasableName(NATFlag.Name, ctx), err)
 	}
 	return natif
 }
@@ -226,19 +226,19 @@ func MakeRPCModules(input string) []string {
 // MakeHTTPRpcHost creates the HTTP RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func MakeHTTPRpcHost(ctx *cli.Context) string {
-	if !ctx.GlobalBool(RPCEnabledFlag.Name) {
+	if !ctx.GlobalBool(aliasableName(RPCEnabledFlag.Name, ctx)) {
 		return ""
 	}
-	return ctx.GlobalString(RPCListenAddrFlag.Name)
+	return ctx.GlobalString(aliasableName(RPCListenAddrFlag.Name, ctx))
 }
 
 // MakeWSRpcHost creates the WebSocket RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func MakeWSRpcHost(ctx *cli.Context) string {
-	if !ctx.GlobalBool(WSEnabledFlag.Name) {
+	if !ctx.GlobalBool(aliasableName(WSEnabledFlag.Name, ctx)) {
 		return ""
 	}
-	return ctx.GlobalString(WSListenAddrFlag.Name)
+	return ctx.GlobalString(aliasableName(WSListenAddrFlag.Name, ctx))
 }
 
 // MakeDatabaseHandles raises out the number of allowed file handles per process
@@ -262,14 +262,14 @@ func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
 	// Create the keystore crypto primitive, light if requested
 	scryptN := accounts.StandardScryptN
 	scryptP := accounts.StandardScryptP
-	if ctx.GlobalBool(LightKDFFlag.Name) {
+	if ctx.GlobalBool(aliasableName(LightKDFFlag.Name, ctx)) {
 		scryptN = accounts.LightScryptN
 		scryptP = accounts.LightScryptP
 	}
 	datadir := MustMakeChainDataDir(ctx)
 
 	keydir := filepath.Join(datadir, "keystore")
-	if path := ctx.GlobalString(KeyStoreDirFlag.Name); path != "" {
+	if path := ctx.GlobalString(aliasableName(KeyStoreDirFlag.Name, ctx)); path != "" {
 		keydir = path
 	}
 
@@ -299,25 +299,25 @@ func MakeAddress(accman *accounts.Manager, account string) (accounts.Account, er
 // command line flags or from the keystore if CLI indexed.
 func MakeEtherbase(accman *accounts.Manager, ctx *cli.Context) common.Address {
 	accounts := accman.Accounts()
-	if !ctx.GlobalIsSet(EtherbaseFlag.Name) && len(accounts) == 0 {
+	if !ctx.GlobalIsSet(aliasableName(EtherbaseFlag.Name, ctx)) && len(accounts) == 0 {
 		glog.V(logger.Error).Infoln("WARNING: No etherbase set and no accounts found as default")
 		return common.Address{}
 	}
-	etherbase := ctx.GlobalString(EtherbaseFlag.Name)
+	etherbase := ctx.GlobalString(aliasableName(EtherbaseFlag.Name, ctx))
 	if etherbase == "" {
 		return common.Address{}
 	}
 	// If the specified etherbase is a valid address, return it
 	account, err := MakeAddress(accman, etherbase)
 	if err != nil {
-		log.Fatalf("Option %q: %v", EtherbaseFlag.Name, err)
+		log.Fatalf("Option %q: %v", aliasableName(EtherbaseFlag.Name, ctx), err)
 	}
 	return account.Address
 }
 
 // MakePasswordList reads password lines from the file specified by --password.
 func MakePasswordList(ctx *cli.Context) []string {
-	path := ctx.GlobalString(PasswordFileFlag.Name)
+	path := ctx.GlobalString(aliasableName(PasswordFileFlag.Name, ctx))
 	if path == "" {
 		return nil
 	}
@@ -353,7 +353,7 @@ func migrateExistingDirToClassicNamingScheme(ctx *cli.Context) error {
 	}
 
 	ethChainDBPath := filepath.Join(ethDataDirPath, "chaindata")
-	if ctx.GlobalIsSet(TestNetFlag.Name) {
+	if ctx.GlobalIsSet(aliasableName(TestNetFlag.Name, ctx)) {
 		ethChainDBPath = filepath.Join(ethDataDirPath, "testnet", "chaindata")
 	}
 
@@ -386,7 +386,7 @@ func migrateExistingDirToClassicNamingScheme(ctx *cli.Context) error {
 	// Only move if defaulty ETC (mainnet or testnet).
 	// Get head block if testnet, fork block if mainnet.
 	b := core.GetBlock(chainDB, core.DefaultConfig.ForkByName("The DAO Hard Fork").RequiredHash)
-	if ctx.GlobalIsSet(TestNetFlag.Name) {
+	if ctx.GlobalIsSet(aliasableName(TestNetFlag.Name, ctx)) {
 		b = core.GetBlock(chainDB, core.GetHeadFastBlockHash(chainDB))
 	}
 
@@ -395,7 +395,7 @@ func migrateExistingDirToClassicNamingScheme(ctx *cli.Context) error {
 	// I think it's safe to assume that the chaindata directory is just too 'young', where it hasn't
 	// synced until block 1920000, and therefore can be migrated.
 	conf := core.DefaultConfig
-	if ctx.GlobalIsSet(TestNetFlag.Name) {
+	if ctx.GlobalIsSet(aliasableName(TestNetFlag.Name, ctx)) {
 		conf = core.TestConfig
 	}
 
@@ -420,7 +420,7 @@ func migrateToChainSubdirIfNecessary(ctx *cli.Context) error {
 	name := getChainConfigIDFromContext(ctx) // "mainnet", "morden", "custom"
 
 	// return ok if custom
-	//if ctx.GlobalIsSet(ChainIDFlag.Name) {
+	//if ctx.GlobalIsSet(aliasableName(ChainIDFlag.Name, ctx)) {
 	//	return nil
 	//}
 
@@ -503,7 +503,7 @@ func migrateToChainSubdirIfNecessary(ctx *cli.Context) error {
 // makeName makes the node name, which can be (in part) customized by the IdentityFlag
 func makeNodeName(version string, ctx *cli.Context) string {
 	name := fmt.Sprintf("Geth/%s/%s/%s", version, runtime.GOOS, runtime.Version())
-	if identity := ctx.GlobalString(IdentityFlag.Name); len(identity) > 0 {
+	if identity := ctx.GlobalString(aliasableName(IdentityFlag.Name, ctx)); len(identity) > 0 {
 		name += "/" + identity
 	}
 	return name
@@ -516,10 +516,10 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 
 	// global settings
 
-	if ctx.GlobalIsSet(ExtraDataFlag.Name) {
-		s := ctx.GlobalString(ExtraDataFlag.Name)
+	if ctx.GlobalIsSet(aliasableName(ExtraDataFlag.Name, ctx)) {
+		s := ctx.GlobalString(aliasableName(ExtraDataFlag.Name, ctx))
 		if len(s) > types.HeaderExtraMax {
-			log.Fatalf("%s flag %q exceeds size limit of %d", ExtraDataFlag.Name, s, types.HeaderExtraMax)
+			log.Fatalf("%s flag %q exceeds size limit of %d", aliasableName(ExtraDataFlag.Name, ctx), s, types.HeaderExtraMax)
 		}
 		miner.HeaderExtra = []byte(s)
 	}
@@ -534,7 +534,7 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 	// Only do this if --datadir flag is not specified AND <home>/<EthereumClassic> does NOT already exist (only migrate once and only for defaulty).
 	// If it finds an 'Ethereum' directory, it will check if it contains default ETC or ETHF chain data.
 	// If it contains ETC data, it will rename the dir. If ETHF data, if will do nothing.
-	if !ctx.GlobalIsSet(DataDirFlag.Name) &&
+	if !ctx.GlobalIsSet(aliasableName(DataDirFlag.Name, ctx)) &&
 		// Allows to use --chainconfig flag as long configuration specifies mainnet or morden
 		(config.ID == core.DefaultTestnetChainConfigID || config.ID == core.DefaultChainConfigID) {
 		if migrationError := migrateExistingDirToClassicNamingScheme(ctx); migrationError != nil {
@@ -565,21 +565,21 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 		DataDir:         MustMakeChainDataDir(ctx),
 		PrivateKey:      MakeNodeKey(ctx),
 		Name:            name,
-		NoDiscovery:     ctx.GlobalBool(NoDiscoverFlag.Name),
+		NoDiscovery:     ctx.GlobalBool(aliasableName(NoDiscoverFlag.Name, ctx)),
 		BootstrapNodes:  config.ParsedBootstrap,
 		ListenAddr:      MakeListenAddress(ctx),
 		NAT:             MakeNAT(ctx),
-		MaxPeers:        ctx.GlobalInt(MaxPeersFlag.Name),
-		MaxPendingPeers: ctx.GlobalInt(MaxPendingPeersFlag.Name),
+		MaxPeers:        ctx.GlobalInt(aliasableName(MaxPeersFlag.Name, ctx)),
+		MaxPendingPeers: ctx.GlobalInt(aliasableName(MaxPendingPeersFlag.Name, ctx)),
 		IPCPath:         MakeIPCPath(ctx),
 		HTTPHost:        MakeHTTPRpcHost(ctx),
-		HTTPPort:        ctx.GlobalInt(RPCPortFlag.Name),
-		HTTPCors:        ctx.GlobalString(RPCCORSDomainFlag.Name),
-		HTTPModules:     MakeRPCModules(ctx.GlobalString(RPCApiFlag.Name)),
+		HTTPPort:        ctx.GlobalInt(aliasableName(RPCPortFlag.Name, ctx)),
+		HTTPCors:        ctx.GlobalString(aliasableName(RPCCORSDomainFlag.Name, ctx)),
+		HTTPModules:     MakeRPCModules(ctx.GlobalString(aliasableName(RPCApiFlag.Name, ctx))),
 		WSHost:          MakeWSRpcHost(ctx),
-		WSPort:          ctx.GlobalInt(WSPortFlag.Name),
-		WSOrigins:       ctx.GlobalString(WSAllowedOriginsFlag.Name),
-		WSModules:       MakeRPCModules(ctx.GlobalString(WSApiFlag.Name)),
+		WSPort:          ctx.GlobalInt(aliasableName(WSPortFlag.Name, ctx)),
+		WSOrigins:       ctx.GlobalString(aliasableName(WSAllowedOriginsFlag.Name, ctx)),
+		WSModules:       MakeRPCModules(ctx.GlobalString(aliasableName(WSApiFlag.Name, ctx))),
 	}
 
 	// Configure the Ethereum service
@@ -587,66 +587,66 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 
 	ethConf := &eth.Config{
 		ChainConfig:             config.ChainConfig,
-		FastSync:                ctx.GlobalBool(FastSyncFlag.Name),
-		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
-		DatabaseCache:           ctx.GlobalInt(CacheFlag.Name),
+		FastSync:                ctx.GlobalBool(aliasableName(FastSyncFlag.Name, ctx)),
+		BlockChainVersion:       ctx.GlobalInt(aliasableName(BlockchainVersionFlag.Name, ctx)),
+		DatabaseCache:           ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx)),
 		DatabaseHandles:         MakeDatabaseHandles(),
-		NetworkId:               ctx.GlobalInt(NetworkIdFlag.Name),
+		NetworkId:               ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)),
 		AccountManager:          accman,
 		Etherbase:               MakeEtherbase(accman, ctx),
-		MinerThreads:            ctx.GlobalInt(MinerThreadsFlag.Name),
-		NatSpec:                 ctx.GlobalBool(NatspecEnabledFlag.Name),
-		DocRoot:                 ctx.GlobalString(aliasableName(DocRootFlag.Name, ctx)),
+		MinerThreads:            ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)),
+		NatSpec:                 ctx.GlobalBool(aliasableName(NatspecEnabledFlag.Name, ctx)),
+		DocRoot:                 ctx.GlobalString(aliasableName(aliasableName(DocRootFlag.Name, ctx), ctx)),
 		GasPrice:                new(big.Int),
 		GpoMinGasPrice:          new(big.Int),
 		GpoMaxGasPrice:          new(big.Int),
-		GpoFullBlockRatio:       ctx.GlobalInt(GpoFullBlockRatioFlag.Name),
-		GpobaseStepDown:         ctx.GlobalInt(GpobaseStepDownFlag.Name),
-		GpobaseStepUp:           ctx.GlobalInt(GpobaseStepUpFlag.Name),
-		GpobaseCorrectionFactor: ctx.GlobalInt(GpobaseCorrectionFactorFlag.Name),
-		SolcPath:                ctx.GlobalString(SolcPathFlag.Name),
-		AutoDAG:                 ctx.GlobalBool(AutoDAGFlag.Name) || ctx.GlobalBool(MiningEnabledFlag.Name),
+		GpoFullBlockRatio:       ctx.GlobalInt(aliasableName(GpoFullBlockRatioFlag.Name, ctx)),
+		GpobaseStepDown:         ctx.GlobalInt(aliasableName(GpobaseStepDownFlag.Name, ctx)),
+		GpobaseStepUp:           ctx.GlobalInt(aliasableName(GpobaseStepUpFlag.Name, ctx)),
+		GpobaseCorrectionFactor: ctx.GlobalInt(aliasableName(GpobaseCorrectionFactorFlag.Name, ctx)),
+		SolcPath:                ctx.GlobalString(aliasableName(SolcPathFlag.Name, ctx)),
+		AutoDAG:                 ctx.GlobalBool(aliasableName(AutoDAGFlag.Name, ctx)) || ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)),
 	}
 
-	if _, ok := ethConf.GasPrice.SetString(ctx.GlobalString(GasPriceFlag.Name), 0); !ok {
-		log.Fatalf("malformed %s flag value %q", GasPriceFlag.Name, ctx.GlobalString(GasPriceFlag.Name))
+	if _, ok := ethConf.GasPrice.SetString(ctx.GlobalString(aliasableName(GasPriceFlag.Name, ctx)), 0); !ok {
+		log.Fatalf("malformed %s flag value %q", aliasableName(GasPriceFlag.Name, ctx), ctx.GlobalString(aliasableName(GasPriceFlag.Name, ctx)))
 	}
-	if _, ok := ethConf.GpoMinGasPrice.SetString(ctx.GlobalString(GpoMinGasPriceFlag.Name), 0); !ok {
-		log.Fatalf("malformed %s flag value %q", GpoMinGasPriceFlag.Name, ctx.GlobalString(GpoMinGasPriceFlag.Name))
+	if _, ok := ethConf.GpoMinGasPrice.SetString(ctx.GlobalString(aliasableName(GpoMinGasPriceFlag.Name, ctx)), 0); !ok {
+		log.Fatalf("malformed %s flag value %q", aliasableName(GpoMinGasPriceFlag.Name, ctx), ctx.GlobalString(aliasableName(GpoMinGasPriceFlag.Name, ctx)))
 	}
-	if _, ok := ethConf.GpoMaxGasPrice.SetString(ctx.GlobalString(GpoMaxGasPriceFlag.Name), 0); !ok {
-		log.Fatalf("malformed %s flag value %q", GpoMaxGasPriceFlag.Name, ctx.GlobalString(GpoMaxGasPriceFlag.Name))
+	if _, ok := ethConf.GpoMaxGasPrice.SetString(ctx.GlobalString(aliasableName(GpoMaxGasPriceFlag.Name, ctx)), 0); !ok {
+		log.Fatalf("malformed %s flag value %q", aliasableName(GpoMaxGasPriceFlag.Name, ctx), ctx.GlobalString(aliasableName(GpoMaxGasPriceFlag.Name, ctx)))
 	}
 
 	// Configure the Whisper service
-	shhEnable := ctx.GlobalBool(WhisperEnabledFlag.Name)
+	shhEnable := ctx.GlobalBool(aliasableName(WhisperEnabledFlag.Name, ctx))
 
 	// Override any default configs in dev mode or the test net
 	switch {
-	case ctx.GlobalBool(TestNetFlag.Name):
-		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
+	case ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)):
+		if !ctx.GlobalIsSet(aliasableName(NetworkIdFlag.Name, ctx)) {
 			ethConf.NetworkId = 2
 		}
 		ethConf.Genesis = core.TestNetGenesis
 		state.StartingNonce = 1048576 // (2**20)
 
-	case ctx.GlobalBool(DevModeFlag.Name):
+	case ctx.GlobalBool(aliasableName(DevModeFlag.Name, ctx)):
 		// Override the base network stack configs
-		if !ctx.GlobalIsSet(DataDirFlag.Name) {
+		if !ctx.GlobalIsSet(aliasableName(DataDirFlag.Name, ctx)) {
 			stackConf.DataDir = filepath.Join(os.TempDir(), "/ethereum_dev_mode")
 		}
-		if !ctx.GlobalIsSet(MaxPeersFlag.Name) {
+		if !ctx.GlobalIsSet(aliasableName(MaxPeersFlag.Name, ctx)) {
 			stackConf.MaxPeers = 0
 		}
-		if !ctx.GlobalIsSet(ListenPortFlag.Name) {
+		if !ctx.GlobalIsSet(aliasableName(ListenPortFlag.Name, ctx)) {
 			stackConf.ListenAddr = ":0"
 		}
 		// Override the Ethereum protocol configs
 		ethConf.Genesis = core.TestNetGenesis
-		if !ctx.GlobalIsSet(GasPriceFlag.Name) {
+		if !ctx.GlobalIsSet(aliasableName(GasPriceFlag.Name, ctx)) {
 			ethConf.GasPrice = new(big.Int)
 		}
-		if !ctx.GlobalIsSet(WhisperEnabledFlag.Name) {
+		if !ctx.GlobalIsSet(aliasableName(WhisperEnabledFlag.Name, ctx)) {
 			shhEnable = true
 		}
 		ethConf.PowTest = true
@@ -693,24 +693,23 @@ func mustMakeSufficientConfiguration(ctx *cli.Context) *core.SufficientChainConf
 	config := &core.SufficientChainConfig{}
 
 	// If external JSON --chainconfig specified.
-	if ctx.GlobalIsSet(UseChainConfigFlag.Name) {
+	if ctx.GlobalIsSet(aliasableName(UseChainConfigFlag.Name, ctx)) {
 		glog.V(logger.Info).Info(fmt.Sprintf("Using custom chain configuration file: \x1b[32m%s\x1b[39m",
-			filepath.Clean(ctx.GlobalString(UseChainConfigFlag.Name))))
+			filepath.Clean(ctx.GlobalString(aliasableName(UseChainConfigFlag.Name, ctx)))))
 
 		// Returns surely valid suff chain config.
-		config, err := core.ReadExternalChainConfig(ctx.GlobalString(UseChainConfigFlag.Name))
+		config, err := core.ReadExternalChainConfig(ctx.GlobalString(aliasableName(UseChainConfigFlag.Name, ctx)))
 		if err != nil {
 			panic(err)
 		}
 
 		// Check for flagged bootnodes.
-		if ctx.GlobalIsSet(BootnodesFlag.Name) {
+		if ctx.GlobalIsSet(aliasableName(BootnodesFlag.Name, ctx)) {
 			panic("Conflicting --chainconfig and --bootnodes flags. Please use either but not both.")
 		}
 
 		currentChainID = config.ID // Set global var.
 		logChainConfiguration(ctx, config.ChainConfig)
-
 
 		chainDB := MakeChainDatabase(ctx)
 		block, err := core.WriteGenesisBlock(chainDB, config.Genesis)
@@ -749,7 +748,7 @@ func logChainConfiguration(ctx *cli.Context, config *core.ChainConfig) {
 		}
 	}
 
-	if ctx.GlobalBool(TestNetFlag.Name) {
+	if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 		glog.V(logger.Warn).Info("Geth is configured to use the \x1b[33mEthereum (ETC) Testnet\x1b[39m blockchain!")
 	} else {
 		glog.V(logger.Warn).Info("Geth is configured to use the \x1b[32mEthereum (ETC) Classic\x1b[39m blockchain!")
@@ -761,7 +760,7 @@ func logChainConfiguration(ctx *cli.Context, config *core.ChainConfig) {
 func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainConfig {
 
 	c := core.DefaultConfig
-	if ctx.GlobalBool(TestNetFlag.Name) {
+	if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 		c = core.TestConfig
 	}
 
@@ -783,7 +782,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 func MakeChainDatabase(ctx *cli.Context) ethdb.Database {
 	var (
 		datadir = MustMakeChainDataDir(ctx)
-		cache   = ctx.GlobalInt(CacheFlag.Name)
+		cache   = ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx))
 		handles = MakeDatabaseHandles()
 	)
 
@@ -802,7 +801,7 @@ func MakeChain(ctx *cli.Context) (chain *core.BlockChain, chainDb ethdb.Database
 	chainConfig := MustMakeChainConfigFromDb(ctx, chainDb)
 
 	pow := pow.PoW(core.FakePow{})
-	if !ctx.GlobalBool(FakePoWFlag.Name) {
+	if !ctx.GlobalBool(aliasableName(FakePoWFlag.Name, ctx)) {
 		pow = ethash.New()
 	}
 	chain, err = core.NewBlockChain(chainDb, chainConfig, pow, new(event.TypeMux))
@@ -816,14 +815,14 @@ func MakeChain(ctx *cli.Context) (chain *core.BlockChain, chainDb ethdb.Database
 // scripts to preload before starting.
 func MakeConsolePreloads(ctx *cli.Context) []string {
 	// Skip preloading if there's nothing to preload
-	if ctx.GlobalString(PreloadJSFlag.Name) == "" {
+	if ctx.GlobalString(aliasableName(PreloadJSFlag.Name, ctx)) == "" {
 		return nil
 	}
 	// Otherwise resolve absolute paths and return them
 	preloads := []string{}
 
-	assets := ctx.GlobalString(JSpathFlag.Name)
-	for _, file := range strings.Split(ctx.GlobalString(PreloadJSFlag.Name), ",") {
+	assets := ctx.GlobalString(aliasableName(JSpathFlag.Name, ctx))
+	for _, file := range strings.Split(ctx.GlobalString(aliasableName(PreloadJSFlag.Name, ctx)), ",") {
 		preloads = append(preloads, common.EnsureAbsolutePath(assets, strings.TrimSpace(file)))
 	}
 	return preloads

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -201,7 +201,7 @@ func MakeBootstrapNodesFromContext(ctx *cli.Context) []*discover.Node {
 // MakeListenAddress creates a TCP listening address string from set command
 // line flags.
 func MakeListenAddress(ctx *cli.Context) string {
-	return fmt.Sprintf(":%d", ListenPortFlag.Value)
+	return fmt.Sprintf(":%d", ctx.GlobalInt(aliasableName(ListenPortFlag.Name, ctx)))
 }
 
 // MakeNAT creates a port mapper from set command line flags.
@@ -569,15 +569,15 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 		BootstrapNodes:  config.ParsedBootstrap,
 		ListenAddr:      MakeListenAddress(ctx),
 		NAT:             MakeNAT(ctx),
-		MaxPeers:        MaxPeersFlag.Value,
-		MaxPendingPeers: MaxPendingPeersFlag.Value,
+		MaxPeers:        ctx.GlobalInt(aliasableName(MaxPeersFlag.Name, ctx)),
+		MaxPendingPeers: ctx.GlobalInt(aliasableName(MaxPendingPeersFlag.Name, ctx)),
 		IPCPath:         MakeIPCPath(ctx),
 		HTTPHost:        MakeHTTPRpcHost(ctx),
-		HTTPPort:        RPCPortFlag.Value,
+		HTTPPort:        ctx.GlobalInt(aliasableName(RPCPortFlag.Name, ctx)),
 		HTTPCors:        ctx.GlobalString(aliasableName(RPCCORSDomainFlag.Name, ctx)),
 		HTTPModules:     MakeRPCModules(ctx.GlobalString(aliasableName(RPCApiFlag.Name, ctx))),
 		WSHost:          MakeWSRpcHost(ctx),
-		WSPort:          WSPortFlag.Value,
+		WSPort:          ctx.GlobalInt(aliasableName(WSPortFlag.Name, ctx)),
 		WSOrigins:       ctx.GlobalString(aliasableName(WSAllowedOriginsFlag.Name, ctx)),
 		WSModules:       MakeRPCModules(ctx.GlobalString(aliasableName(WSApiFlag.Name, ctx))),
 	}
@@ -588,22 +588,22 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 	ethConf := &eth.Config{
 		ChainConfig:             config.ChainConfig,
 		FastSync:                ctx.GlobalBool(aliasableName(FastSyncFlag.Name, ctx)),
-		BlockChainVersion:       BlockchainVersionFlag.Value,
-		DatabaseCache:           CacheFlag.Value,
+		BlockChainVersion:       ctx.GlobalInt(aliasableName(BlockchainVersionFlag.Name, ctx)),
+		DatabaseCache:           ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx)),
 		DatabaseHandles:         MakeDatabaseHandles(),
-		NetworkId:               NetworkIdFlag.Value,
+		NetworkId:               ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)),
 		AccountManager:          accman,
 		Etherbase:               MakeEtherbase(accman, ctx),
-		MinerThreads:            MinerThreadsFlag.Value,
+		MinerThreads:            ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)),
 		NatSpec:                 ctx.GlobalBool(aliasableName(NatspecEnabledFlag.Name, ctx)),
 		DocRoot:                 ctx.GlobalString(aliasableName(aliasableName(DocRootFlag.Name, ctx), ctx)),
 		GasPrice:                new(big.Int),
 		GpoMinGasPrice:          new(big.Int),
 		GpoMaxGasPrice:          new(big.Int),
-		GpoFullBlockRatio:       GpoFullBlockRatioFlag.Value,
-		GpobaseStepDown:         GpobaseStepDownFlag.Value,
-		GpobaseStepUp:           GpobaseStepUpFlag.Value,
-		GpobaseCorrectionFactor: GpobaseCorrectionFactorFlag.Value,
+		GpoFullBlockRatio:       ctx.GlobalInt(aliasableName(GpoFullBlockRatioFlag.Name, ctx)),
+		GpobaseStepDown:         ctx.GlobalInt(aliasableName(GpobaseStepDownFlag.Name, ctx)),
+		GpobaseStepUp:           ctx.GlobalInt(aliasableName(GpobaseStepUpFlag.Name, ctx)),
+		GpobaseCorrectionFactor: ctx.GlobalInt(aliasableName(GpobaseCorrectionFactorFlag.Name, ctx)),
 		SolcPath:                ctx.GlobalString(aliasableName(SolcPathFlag.Name, ctx)),
 		AutoDAG:                 ctx.GlobalBool(aliasableName(AutoDAGFlag.Name, ctx)) || ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)),
 	}
@@ -782,7 +782,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 func MakeChainDatabase(ctx *cli.Context) ethdb.Database {
 	var (
 		datadir = MustMakeChainDataDir(ctx)
-		cache   = CacheFlag.Value
+		cache   = ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx))
 		handles = MakeDatabaseHandles()
 	)
 

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -132,7 +132,7 @@ func getChainConfigNameFromContext(ctx *cli.Context) string {
 // if none (or the empty string) is specified.
 // --> <home>/<EthereumClassic>(defaulty) or --datadir
 func mustMakeDataDir(ctx *cli.Context) string {
-	if path := ctx.GlobalString(DataDirFlag.Name); path != "" {
+	if path := ctx.GlobalString(aliasableName(DataDirFlag.Name, ctx)); path != "" {
 		return path
 	}
 	log.Fatal("Cannot determine data directory, please set manually (--datadir)")
@@ -152,7 +152,7 @@ func MakeIPCPath(ctx *cli.Context) string {
 	if ctx.GlobalBool(IPCDisabledFlag.Name) {
 		return ""
 	}
-	return ctx.GlobalString(IPCPathFlag.Name)
+	return ctx.GlobalString(aliasableName(IPCPathFlag.Name, ctx))
 }
 
 // MakeNodeKey creates a node key from set command line flags, either loading it
@@ -596,7 +596,7 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 		Etherbase:               MakeEtherbase(accman, ctx),
 		MinerThreads:            ctx.GlobalInt(MinerThreadsFlag.Name),
 		NatSpec:                 ctx.GlobalBool(NatspecEnabledFlag.Name),
-		DocRoot:                 ctx.GlobalString(DocRootFlag.Name),
+		DocRoot:                 ctx.GlobalString(aliasableName(DocRootFlag.Name, ctx)),
 		GasPrice:                new(big.Int),
 		GpoMinGasPrice:          new(big.Int),
 		GpoMaxGasPrice:          new(big.Int),

--- a/cmd/geth/flag_test.go
+++ b/cmd/geth/flag_test.go
@@ -1,97 +1,229 @@
 package main
 
 import (
-	"testing"
-	"io/ioutil"
 	"flag"
-	"gopkg.in/urfave/cli.v1"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
+
 	"github.com/ethereumproject/go-ethereum/common"
+	"gopkg.in/urfave/cli.v1"
 )
+
+var ogHome string  // placeholder
+var tmpHOME string // fake $HOME (for defaults)
+var tmpDir string  // temp DATA_DIR (inside tmpHOME)
 
 var app *cli.App
 var context *cli.Context
-var tmpDir string
 
 var set *flag.FlagSet
-//var datadir string
+
+// globally available flags that go will parse, making them available for the mock app
+type flags []struct {
+	name    string
+	aliases []string
+	value   interface{}
+}
+
+var gFlags flags
 
 func makeTmpDataDir(t *testing.T) {
-	home := common.HomeDir()
+	ogHome = common.HomeDir()
+	var e error
 
-	td, err := ioutil.TempDir(home, "tmp")
+	tmpHOME, e = ioutil.TempDir(ogHome, "HOME")
+	if e != nil {
+		t.Fatalf("Failed to create temp directory in: %v", ogHome)
+	}
+
+	if e = os.Setenv("HOME", tmpHOME); e != nil {
+		t.Fatalf("Failed to temporarily set system home: %v", e)
+	}
+
+	td, err := ioutil.TempDir(tmpHOME, "DATADIR")
 	if err != nil {
-		t.Fatalf("Failed to create temp directory in: %v", home)
+		t.Fatalf("Failed to create temp directory in: %v", tmpHOME)
 	}
 	tmpDir = td
 }
 
 func rmTmpDataDir(t *testing.T) {
-	if e := os.RemoveAll(tmpDir); e != nil {
+	if e := os.RemoveAll(tmpHOME); e != nil {
 		t.Fatalf("Failed to remove temp dir: %v", e)
+	}
+
+	if e := os.Setenv("HOME", ogHome); e != nil {
+		t.Fatalf("Failed to reset system home env var: %v", e)
 	}
 }
 
 func setupFlags(t *testing.T) {
+
+	gFlags = flags{
+		{"testnet", []string{}, false},
+		{"data-dir", []string{"datadir"}, common.DefaultDataDir()},
+		{"bootnodes", []string{}, ""},
+	}
+
 	app = makeCLIApp()
 	app.Writer = ioutil.Discard
 
 	set = flag.NewFlagSet("test", 0)
 
-	set.String("datadir", "", "")
+	for _, f := range gFlags {
+		switch f.value.(type) {
+		case string:
+			set.String(f.name, f.value.(string), "")
+		case bool:
+			set.Bool(f.name, f.value.(bool), "")
+		case int:
+			set.Int(f.name, f.value.(int), "")
+		}
+
+		if len(f.aliases) > 0 {
+			for _, a := range f.aliases {
+				switch f.value.(type) {
+				case string:
+					set.String(a, f.value.(string), "")
+				case bool:
+					set.Bool(a, f.value.(bool), "")
+				case int:
+					set.Int(a, f.value.(int), "")
+				}
+			}
+		}
+	}
 }
 
 func TestMustMakeChainDataDir(t *testing.T) {
 
 	makeTmpDataDir(t)
+
+	cases := []struct {
+		flags []string
+		want  string
+		err   error
+	}{
+		{[]string{"--datadir", tmpDir}, filepath.Join(tmpDir, "mainnet"), nil},
+		{[]string{"--data-dir", tmpDir}, filepath.Join(tmpDir, "mainnet"), nil},
+		{[]string{}, filepath.Join(common.DefaultDataDir(), "mainnet"), nil},
+		{[]string{"--testnet"}, filepath.Join(common.DefaultDataDir(), "morden"), nil},
+		{[]string{"--testnet", "--data-dir", tmpDir}, filepath.Join(tmpDir, "morden"), nil},
+	}
+
+	for i, c := range cases {
+		setupFlags(t)
+
+		if e := set.Parse(c.flags); e != nil {
+			t.Fatal(e)
+		}
+		context = cli.NewContext(app, set, nil)
+
+		got := MustMakeChainDataDir(context)
+
+		if c.err == nil && got != c.want {
+			t.Errorf("flag: %v, chaindir want: %v, got: %v", i, c.want, got)
+		}
+		if c.err == nil && !filepath.IsAbs(got) {
+			t.Errorf("flag: %v, unexpected relative path: %v", i, got)
+		}
+		if c.err != nil && got != "" {
+			t.Errorf("flag: %v, want: %v, got: %v", i, c.err, got)
+		}
+	}
+	rmTmpDataDir(t)
+}
+
+// Bootnodes flag parse 1
+func TestMakeBootstrapNodesFromContext1(t *testing.T) {
+
+	makeTmpDataDir(t)
 	setupFlags(t)
 
-	args := []string{"--datadir", tmpDir}
-	if e := set.Parse(args); e != nil {
+	arg := []string{
+		"--bootnodes",
+		"enode://6e538e7c1280f0a31ff08b382db5302480f775480b8e68f8febca0ceff81e4b19153c6f8bf60313b93bef2cc34d34e1df41317de0ce613a201d1660a788a03e2@52.206.67.235:30303",
+	}
+	if e := set.Parse(arg); e != nil {
 		t.Fatal(e)
 	}
-
 	context = cli.NewContext(app, set, nil)
-
-	got := MustMakeChainDataDir(context)
-	expected := filepath.Join(tmpDir, "mainnet")
-	if got != expected {
-		t.Errorf("chaindir want: %v, got: %v", expected, got)
+	got := MakeBootstrapNodesFromContext(context)
+	if len(got) != 1 {
+		t.Errorf("wanted: 1, got %v", len(got))
 	}
-	if !filepath.IsAbs(got) {
-		t.Errorf("unexpected relative path: %v", got)
+	if got[0].IP.String() != "52.206.67.235" {
+		t.Errorf("unexpected: %v", got[0].IP.String())
 	}
 
 	rmTmpDataDir(t)
 }
 
-//func TestMustMakeChainConfig(t *testing.T) {
-//
-//	cases := []struct{
-//		args []string
-//		expectedResult interface{}
-//		expectedErr error
-//	}{
-//		{[]string{"geth", "data-dir", tmpDir}, nil, nil},
-//	}
-//
-//	for _, c := range cases {
-//		makeTmpDataDir(c.args, t)
-//		cmd := cli.Command{
-//			Action: version,
-//				Name:   "version",
-//				Usage:  "print ethereum version numbers",
-//				Description: `
-//	The output of this command is supposed to be machine-readable.
-//	`,
-//		}
-//		err := cmd.Run(context)
-//		if err != c.expectedErr {
-//			t.Errorf("error: %v", err)
-//		}
-//		rmTmpDataDir(t)
-//	}
-//
-//}
+// Bootnodes flag parse 2
+func TestMakeBootstrapNodesFromContext2(t *testing.T) {
+
+	makeTmpDataDir(t)
+	setupFlags(t)
+
+	arg := []string{
+		"--bootnodes",
+		`enode://6e538e7c1280f0a31ff08b382db5302480f775480b8e68f8febca0ceff81e4b19153c6f8bf60313b93bef2cc34d34e1df41317de0ce613a201d1660a788a03e2@52.206.67.235:30303,enode://f50e675a34f471af2438b921914b5f06499c7438f3146f6b8936f1faeb50b8a91d0d0c24fb05a66f05865cd58c24da3e664d0def806172ddd0d4c5bdbf37747e@144.76.238.49:30306`,
+	}
+	if e := set.Parse(arg); e != nil {
+		t.Fatal(e)
+	}
+	context = cli.NewContext(app, set, nil)
+	got := MakeBootstrapNodesFromContext(context)
+	if len(got) != 2 {
+		t.Errorf("wanted: 2, got %v", len(got))
+	}
+	if got[0].IP.String() != "52.206.67.235" {
+		t.Errorf("unexpected: %v", got[0].IP.String())
+	}
+	if got[1].IP.String() != "144.76.238.49" {
+		t.Errorf("unexpected: %v", got[1].IP.String())
+	}
+
+	rmTmpDataDir(t)
+}
+
+// Bootnodes default
+func TestMakeBootstrapNodesFromContext3(t *testing.T) {
+
+	makeTmpDataDir(t)
+	setupFlags(t)
+
+	arg := []string{}
+	if e := set.Parse(arg); e != nil {
+		t.Fatal(e)
+	}
+	context = cli.NewContext(app, set, nil)
+	got := MakeBootstrapNodesFromContext(context)
+	if len(got) != len(HomesteadBootNodes) {
+		t.Errorf("wanted: %v, got %v", len(HomesteadBootNodes), len(got))
+	}
+
+	rmTmpDataDir(t)
+}
+
+// Bootnodes testnet default
+func TestMakeBootstrapNodesFromContext4(t *testing.T) {
+
+	makeTmpDataDir(t)
+	setupFlags(t)
+
+	arg := []string{"--testnet"}
+	if e := set.Parse(arg); e != nil {
+		t.Fatal(e)
+	}
+	context = cli.NewContext(app, set, nil)
+	got := MakeBootstrapNodesFromContext(context)
+	if len(got) != len(TestNetBootNodes) {
+		t.Errorf("wanted: %v, got %v", len(TestNetBootNodes), len(got))
+	}
+
+	rmTmpDataDir(t)
+}
 

--- a/cmd/geth/flag_test.go
+++ b/cmd/geth/flag_test.go
@@ -1,125 +1,97 @@
 package main
 
 import (
-	"os"
+	"testing"
+	"io/ioutil"
 	"flag"
-	"fmt"
+	"gopkg.in/urfave/cli.v1"
+	"os"
+	"path/filepath"
+	"github.com/ethereumproject/go-ethereum/common"
 )
 
-// This doesn't work and I don't know why not...
-func ExampleRunCLIAppHelp() {
-	os.Args = []string{"geth", "help"}
-	flag.Parse()
-	app := makeCLIApp()
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+var app *cli.App
+var context *cli.Context
+var tmpDir string
+
+var set *flag.FlagSet
+//var datadir string
+
+func makeTmpDataDir(t *testing.T) {
+	home := common.HomeDir()
+
+	td, err := ioutil.TempDir(home, "tmp")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory in: %v", home)
 	}
-	// Output:
-	// geth - the go-ethereum command line interface
-	// NAME:
-
-	// USAGE:
-	//    geth [options] command [command options] [arguments...]
-	// VERSION:
-	//    source
-	// COMMANDS:
-	//    import			import a blockchain file
-	//    export			export blockchain into file
-	//    upgradedb			upgrade chainblock database
-	//    removedb			Remove blockchain and state databases
-	//    dump				dump a specific block from storage
-	//    monitor			Geth Monitor: node metrics monitoring and visualization
-	//    account			manage accounts
-	//    wallet			ethereum presale wallet
-	//    console			Geth Console: interactive JavaScript environment
-	//    attach			Geth Console: interactive JavaScript environment (connect to node)
-	//    js				executes the given JavaScript files in the Geth JavaScript VM
-	//    makedag			generate ethash dag (for testing)
-	//    gpuinfo			gpuinfo
-	//    gpubench			benchmark GPU
-	//    version			print ethereum version numbers
-	//    init				bootstraps and initialises a new genesis block (JSON)
-	//    dumpChainConfig	dump current chain configuration to JSON file [REQUIRED argument: filepath.json]
-	//    help, h			Shows a list of commands or help for one command
-
-	// ETHEREUM OPTIONS:
-	//   --datadir "/Users/ia/Library/EthereumClassic"	Data directory for the databases and keystore
-	//   --keystore 					Directory for the keystore (default = inside the datadir)
-	//   --networkid value				Network identifier (integer, 0=Olympic, 1=Homestead, 2=Morden) (default: 1)
-	//   --testnet					Morden network: pre-configured test network with modified starting nonces (replay protection)
-	//   --dev						Developer mode: pre-configured private network with several debugging flags
-	//   --identity value				Custom node name
-	//   --fast					Enable fast syncing through state downloads
-	//   --lightkdf					Reduce key-derivation RAM & CPU usage at some expense of KDF strength
-	//   --cache value					Megabytes of memory allocated to internal caching (min 16MB / database forced) (default: 128)
-	//   --blockchainversion value			Blockchain version (integer) (default: 3)
-
-	// ACCOUNT OPTIONS:
-	//   --unlock value	Comma separated list of accounts to unlock
-	//   --password value	Password file to use for non-inteactive password input
-
-	// API AND CONSOLE OPTIONS:
-	//   --rpc			Enable the HTTP-RPC server
-	//   --rpcaddr value	HTTP-RPC server listening interface (default: "localhost")
-	//   --rpcport value	HTTP-RPC server listening port (default: 8545)
-	//   --rpcapi value	API's offered over the HTTP-RPC interface (default: "eth,net,web3")
-	//   --ws			Enable the WS-RPC server
-	//   --wsaddr value	WS-RPC server listening interface (default: "localhost")
-	//   --wsport value	WS-RPC server listening port (default: 8546)
-	//   --wsapi value		API's offered over the WS-RPC interface (default: "eth,net,web3")
-	//   --wsorigins value	Origins from which to accept websockets requests
-	//   --ipcdisable		Disable the IPC-RPC server
-	//   --ipcapi value	API's offered over the IPC-RPC interface (default: "admin,debug,eth,miner,net,personal,shh,txpool,web3")
-	//   --ipcpath "geth.ipc"	Filename for IPC socket/pipe within the datadir (explicit paths escape it)
-	//   --rpccorsdomain value	Comma separated list of domains from which to accept cross origin requests (browser enforced)
-	//   --jspath loadScript	JavaScript root path for loadScript and document root for `admin.httpGet` (default: ".")
-	//   --exec value		Execute JavaScript statement (only in combination with console/attach)
-	//   --preload value	Comma separated list of JavaScript files to preload into the console
-
-	// NETWORKING OPTIONS:
-	//   --bootnodes value	Comma separated enode URLs for P2P discovery bootstrap
-	//   --port value		Network listening port (default: 30303)
-	//   --maxpeers value	Maximum number of network peers (network disabled if set to 0) (default: 25)
-	//   --maxpendpeers value	Maximum number of pending connection attempts (defaults used if set to 0) (default: 0)
-	//   --nat value		NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: "any")
-	//   --nodiscover		Disables the peer discovery mechanism (manual peer addition)
-	//   --nodekey value	P2P node key file
-	//   --nodekeyhex value	P2P node key as hex (for testing)
-
-	// MINER OPTIONS:
-	//   --mine			Enable mining
-	//   --minerthreads value		Number of CPU threads to use for mining (default: 2)
-	//   --minergpus value		List of GPUs to use for mining (e.g. '0,1' will use the first two GPUs found)
-	//   --autodag			Enable automatic DAG pregeneration
-	//   --etherbase value		Public address for block mining rewards (default = first account created) (default: "0")
-	//   --targetgaslimit value	Target gas limit sets the artificial target gas floor for the blocks to mine (default: "4712388")
-	//   --gasprice value		Minimal gas price to accept for mining a transactions (default: "20000000000")
-	//   --extradata value		Freeform header field set by the miner
-
-	// GAS PRICE ORACLE OPTIONS:
-	//   --gpomin value	Minimum suggested gas price (default: "20000000000")
-	//   --gpomax value	Maximum suggested gas price (default: "500000000000")
-	//   --gpofull value	Full block threshold for gas price calculation (%) (default: 80)
-	//   --gpobasedown value	Suggested gas price base step down ratio (1/1000) (default: 10)
-	//   --gpobaseup value	Suggested gas price base step up ratio (1/1000) (default: 100)
-	//   --gpobasecf value	Suggested gas price base correction factor (%) (default: 110)
-
-	// LOGGING AND DEBUGGING OPTIONS:
-	//   --verbosity value	Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=core, 5=debug, 6=detail (default: 3)
-	//   --vmodule value	Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=6,p2p=5)
-	//   --backtrace value	Request a stack trace at a specific logging statement (e.g. "block.go:271") (default: :0)
-	//   --metrics value	Enables metrics reporting. When the value is a path, either relative or absolute, then a log is written to the respective file.
-	//   --fakepow		Disables proof-of-work verification
-
-	// EXPERIMENTAL OPTIONS:
-	//   --shh		Enable Whisper
-	//   --natspec	Enable NatSpec confirmation notice
-
-	// MISCELLANEOUS OPTIONS:
-	//   --solc value		Solidity compiler command to be used (default: "solc")
-	//   --chainconfig value	Specify a JSON format chain configuration file to use.
-	//   --chain value		Name of blockchain network to use (default='mainnnet', test='testnet'). These correlate to subdirectories under your base <EthereumClassic> data directory (--datadir). Chain name to use can also be configured from an external chain configuration file. (default: "mainnet")
-	//   --oppose-dao-fork	Use classic blockchain (always set, flag is unused and exists for compatibility only)
-	//   --help, -h		show hel
+	tmpDir = td
 }
+
+func rmTmpDataDir(t *testing.T) {
+	if e := os.RemoveAll(tmpDir); e != nil {
+		t.Fatalf("Failed to remove temp dir: %v", e)
+	}
+}
+
+func setupFlags(t *testing.T) {
+	app = makeCLIApp()
+	app.Writer = ioutil.Discard
+
+	set = flag.NewFlagSet("test", 0)
+
+	set.String("datadir", "", "")
+}
+
+func TestMustMakeChainDataDir(t *testing.T) {
+
+	makeTmpDataDir(t)
+	setupFlags(t)
+
+	args := []string{"--datadir", tmpDir}
+	if e := set.Parse(args); e != nil {
+		t.Fatal(e)
+	}
+
+	context = cli.NewContext(app, set, nil)
+
+	got := MustMakeChainDataDir(context)
+	expected := filepath.Join(tmpDir, "mainnet")
+	if got != expected {
+		t.Errorf("chaindir want: %v, got: %v", expected, got)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("unexpected relative path: %v", got)
+	}
+
+	rmTmpDataDir(t)
+}
+
+//func TestMustMakeChainConfig(t *testing.T) {
+//
+//	cases := []struct{
+//		args []string
+//		expectedResult interface{}
+//		expectedErr error
+//	}{
+//		{[]string{"geth", "data-dir", tmpDir}, nil, nil},
+//	}
+//
+//	for _, c := range cases {
+//		makeTmpDataDir(c.args, t)
+//		cmd := cli.Command{
+//			Action: version,
+//				Name:   "version",
+//				Usage:  "print ethereum version numbers",
+//				Description: `
+//	The output of this command is supposed to be machine-readable.
+//	`,
+//		}
+//		err := cmd.Run(context)
+//		if err != c.expectedErr {
+//			t.Errorf("error: %v", err)
+//		}
+//		rmTmpDataDir(t)
+//	}
+//
+//}
+

--- a/cmd/geth/flagdir.go
+++ b/cmd/geth/flagdir.go
@@ -88,7 +88,7 @@ func (self DirectoryFlag) Apply(set *flag.FlagSet) {
 	}
 
 	eachName(self.Name, func(name string) {
-		set.Var(&self.Value, self.Name, self.Usage)
+		set.Var(&self.Value, name, self.Usage)
 	})
 }
 

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -300,7 +300,7 @@ var (
 		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	GpoMaxGasPriceFlag = cli.StringFlag{
-		Name:  "gpo-min, gpomin",
+		Name:  "gpo-max, gpomax",
 		Usage: "Maximum suggested gas price",
 		Value: new(big.Int).Mul(big.NewInt(500), common.Shannon).String(),
 	}

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -29,7 +29,7 @@ var (
 		Value: DirectoryString{common.DefaultDataDir()},
 	}
 	UseChainConfigFlag = cli.StringFlag{
-		Name:  "chain-config, chainconfig",
+		Name:  "chain-config,chainconfig",
 		Usage: "Specify a JSON format chain configuration file to use.",
 	}
 	KeyStoreDirFlag = DirectoryFlag{
@@ -75,7 +75,7 @@ var (
 		Value: 128,
 	}
 	BlockchainVersionFlag = cli.IntFlag{
-		Name:  "blockchain-version, blockchainversion",
+		Name:  "blockchain-version,blockchainversion",
 		Usage: "Blockchain version (integer)",
 		Value: core.BlockChainVersion,
 	}
@@ -84,7 +84,7 @@ var (
 		Usage: "Enable fast syncing through state downloads",
 	}
 	LightKDFFlag = cli.BoolFlag{
-		Name:  "light-kdf, lightkdf",
+		Name:  "light-kdf,lightkdf",
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
 	}
 	// Network Split settings
@@ -99,21 +99,21 @@ var (
 		Usage: "Enable mining",
 	}
 	MinerThreadsFlag = cli.IntFlag{
-		Name:  "miner-threads, minerthreads",
+		Name:  "miner-threads,minerthreads",
 		Usage: "Number of CPU threads to use for mining",
 		Value: runtime.NumCPU(),
 	}
 	MiningGPUFlag = cli.StringFlag{
-		Name:  "miner-gpus, minergpus",
+		Name:  "miner-gpus,minergpus",
 		Usage: "List of GPUs to use for mining (e.g. '0,1' will use the first two GPUs found)",
 	}
 	TargetGasLimitFlag = cli.StringFlag{
-		Name:  "target-gas-limit, targetgaslimit",
+		Name:  "target-gas-limit,targetgaslimit",
 		Usage: "Target gas limit sets the artificial target gas floor for the blocks to mine",
 		Value: core.TargetGasLimit.String(),
 	}
 	AutoDAGFlag = cli.BoolFlag{
-		Name:  "auto-dag, autodag",
+		Name:  "auto-dag,autodag",
 		Usage: "Enable automatic DAG pregeneration",
 	}
 	EtherbaseFlag = cli.StringFlag{
@@ -122,12 +122,12 @@ var (
 		Value: "0",
 	}
 	GasPriceFlag = cli.StringFlag{
-		Name:  "gas-price, gasprice",
+		Name:  "gas-price,gasprice",
 		Usage: "Minimal gas price to accept for mining a transactions",
 		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	ExtraDataFlag = cli.StringFlag{
-		Name:  "extra-data, extradata",
+		Name:  "extra-data,extradata",
 		Usage: "Freeform header field set by the miner",
 	}
 	// Account settings
@@ -173,36 +173,36 @@ var (
 		Usage: "Enable the HTTP-RPC server",
 	}
 	RPCListenAddrFlag = cli.StringFlag{
-		Name:  "rpc-addr, rpcaddr",
+		Name:  "rpc-addr,rpcaddr",
 		Usage: "HTTP-RPC server listening interface",
 		Value: common.DefaultHTTPHost,
 	}
 	RPCPortFlag = cli.IntFlag{
-		Name:  "rpc-port, rpcport",
+		Name:  "rpc-port,rpcport",
 		Usage: "HTTP-RPC server listening port",
 		Value: common.DefaultHTTPPort,
 	}
 	RPCCORSDomainFlag = cli.StringFlag{
-		Name:  "rpc-cors-domain, rpccorsdomain",
+		Name:  "rpc-cors-domain,rpccorsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
 		Value: "",
 	}
 	RPCApiFlag = cli.StringFlag{
-		Name:  "rpc-api, rpcapi",
+		Name:  "rpc-api,rpcapi",
 		Usage: "API's offered over the HTTP-RPC interface",
 		Value: rpc.DefaultHTTPApis,
 	}
 	IPCDisabledFlag = cli.BoolFlag{
-		Name:  "ipc-disable, ipcdisable",
+		Name:  "ipc-disable,ipcdisable",
 		Usage: "Disable the IPC-RPC server",
 	}
 	IPCApiFlag = cli.StringFlag{
-		Name:  "ipc-api, ipcapi",
+		Name:  "ipc-api,ipcapi",
 		Usage: "API's offered over the IPC-RPC interface",
 		Value: rpc.DefaultIPCApis,
 	}
 	IPCPathFlag = DirectoryFlag{
-		Name:  "ipc-path, ipcpath",
+		Name:  "ipc-path,ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 		Value: DirectoryString{common.DefaultIPCSocket},
 	}
@@ -211,22 +211,22 @@ var (
 		Usage: "Enable the WS-RPC server",
 	}
 	WSListenAddrFlag = cli.StringFlag{
-		Name:  "ws-addr, wsaddr",
+		Name:  "ws-addr,wsaddr",
 		Usage: "WS-RPC server listening interface",
 		Value: common.DefaultWSHost,
 	}
 	WSPortFlag = cli.IntFlag{
-		Name:  "ws-port, wsport",
+		Name:  "ws-port,wsport",
 		Usage: "WS-RPC server listening port",
 		Value: common.DefaultWSPort,
 	}
 	WSApiFlag = cli.StringFlag{
-		Name:  "ws-api, wsapi",
+		Name:  "ws-api,wsapi",
 		Usage: "API's offered over the WS-RPC interface",
 		Value: rpc.DefaultHTTPApis,
 	}
 	WSAllowedOriginsFlag = cli.StringFlag{
-		Name:  "ws-origins, wsorigins",
+		Name:  "ws-origins,wsorigins",
 		Usage: "Origins from which to accept websockets requests",
 		Value: "",
 	}
@@ -241,12 +241,12 @@ var (
 
 	// Network Settings
 	MaxPeersFlag = cli.IntFlag{
-		Name:  "max-peers, maxpeers",
+		Name:  "max-peers,maxpeers",
 		Usage: "Maximum number of network peers (network disabled if set to 0)",
 		Value: 25,
 	}
 	MaxPendingPeersFlag = cli.IntFlag{
-		Name:  "max-pend-peers, maxpendpeers",
+		Name:  "max-pend-peers,maxpendpeers",
 		Usage: "Maximum number of pending connection attempts (defaults used if set to 0)",
 		Value: 0,
 	}
@@ -265,7 +265,7 @@ var (
 		Usage: "P2P node key file",
 	}
 	NodeKeyHexFlag = cli.StringFlag{
-		Name:  "nodekey-hex, nodekeyhex",
+		Name:  "nodekey-hex,nodekeyhex",
 		Usage: "P2P node key as hex (for testing)",
 	}
 	NATFlag = cli.StringFlag{
@@ -274,7 +274,7 @@ var (
 		Value: "any",
 	}
 	NoDiscoverFlag = cli.BoolFlag{
-		Name:  "no-discover, nodiscover",
+		Name:  "no-discover,nodiscover",
 		Usage: "Disables the peer discovery mechanism (manual peer addition)",
 	}
 	WhisperEnabledFlag = cli.BoolFlag{
@@ -283,7 +283,7 @@ var (
 	}
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
-		Name:  "js-path, jspath",
+		Name:  "js-path,jspath",
 		Usage: "JavaScript root path for `loadScript` and document root for `admin.httpGet`",
 		Value: ".",
 	}
@@ -295,32 +295,32 @@ var (
 
 	// Gas price oracle settings
 	GpoMinGasPriceFlag = cli.StringFlag{
-		Name:  "gpo-min, gpomin",
+		Name:  "gpo-min,gpomin",
 		Usage: "Minimum suggested gas price",
 		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	GpoMaxGasPriceFlag = cli.StringFlag{
-		Name:  "gpo-max, gpomax",
+		Name:  "gpo-max,gpomax",
 		Usage: "Maximum suggested gas price",
 		Value: new(big.Int).Mul(big.NewInt(500), common.Shannon).String(),
 	}
 	GpoFullBlockRatioFlag = cli.IntFlag{
-		Name:  "gpo-full, gpofull",
+		Name:  "gpo-full,gpofull",
 		Usage: "Full block threshold for gas price calculation (%)",
 		Value: 80,
 	}
 	GpobaseStepDownFlag = cli.IntFlag{
-		Name:  "gpo-base-down, gpobasedown",
+		Name:  "gpo-base-down,gpobasedown",
 		Usage: "Suggested gas price base step down ratio (1/1000)",
 		Value: 10,
 	}
 	GpobaseStepUpFlag = cli.IntFlag{
-		Name:  "gpo-base-up, gpobaseup",
+		Name:  "gpo-base-up,gpobaseup",
 		Usage: "Suggested gas price base step up ratio (1/1000)",
 		Value: 100,
 	}
 	GpobaseCorrectionFactorFlag = cli.IntFlag{
-		Name:  "gpo-base-cf, gpobasecf",
+		Name:  "gpo-base-cf,gpobasecf",
 		Usage: "Suggested gas price base correction factor (%)",
 		Value: 110,
 	}

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -4,13 +4,14 @@ import (
 	"math/big"
 	"runtime"
 
+	"strings"
+
 	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/ethereumproject/go-ethereum/core"
 	"github.com/ethereumproject/go-ethereum/eth"
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
 )
 
 // These are all the command line flags we support.
@@ -28,7 +29,7 @@ var (
 		Value: DirectoryString{common.DefaultDataDir()},
 	}
 	UseChainConfigFlag = cli.StringFlag{
-		Name: "chainconfig",
+		Name:  "chain-config, chainconfig",
 		Usage: "Specify a JSON format chain configuration file to use.",
 	}
 	KeyStoreDirFlag = DirectoryFlag{
@@ -43,7 +44,7 @@ var (
 		Value: core.DefaultChainConfigID,
 	}
 	NetworkIdFlag = cli.IntFlag{
-		Name:  "networkid",
+		Name:  "network-id, networkid",
 		Usage: "Network identifier (integer, 0=Olympic, 1=Homestead, 2=Morden)",
 		Value: eth.NetworkId,
 	}
@@ -74,7 +75,7 @@ var (
 		Value: 128,
 	}
 	BlockchainVersionFlag = cli.IntFlag{
-		Name:  "blockchainversion",
+		Name:  "blockchain-version, blockchainversion",
 		Usage: "Blockchain version (integer)",
 		Value: core.BlockChainVersion,
 	}
@@ -83,7 +84,7 @@ var (
 		Usage: "Enable fast syncing through state downloads",
 	}
 	LightKDFFlag = cli.BoolFlag{
-		Name:  "lightkdf",
+		Name:  "light-kdf, lightkdf",
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
 	}
 	// Network Split settings
@@ -98,21 +99,21 @@ var (
 		Usage: "Enable mining",
 	}
 	MinerThreadsFlag = cli.IntFlag{
-		Name:  "minerthreads",
+		Name:  "miner-threads, minerthreads",
 		Usage: "Number of CPU threads to use for mining",
 		Value: runtime.NumCPU(),
 	}
 	MiningGPUFlag = cli.StringFlag{
-		Name:  "minergpus",
+		Name:  "miner-gpus, minergpus",
 		Usage: "List of GPUs to use for mining (e.g. '0,1' will use the first two GPUs found)",
 	}
 	TargetGasLimitFlag = cli.StringFlag{
-		Name:  "targetgaslimit",
+		Name:  "target-gas-limit, targetgaslimit",
 		Usage: "Target gas limit sets the artificial target gas floor for the blocks to mine",
 		Value: core.TargetGasLimit.String(),
 	}
 	AutoDAGFlag = cli.BoolFlag{
-		Name:  "autodag",
+		Name:  "auto-dag, autodag",
 		Usage: "Enable automatic DAG pregeneration",
 	}
 	EtherbaseFlag = cli.StringFlag{
@@ -121,12 +122,12 @@ var (
 		Value: "0",
 	}
 	GasPriceFlag = cli.StringFlag{
-		Name:  "gasprice",
+		Name:  "gas-price, gasprice",
 		Usage: "Minimal gas price to accept for mining a transactions",
 		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	ExtraDataFlag = cli.StringFlag{
-		Name:  "extradata",
+		Name:  "extra-data, extradata",
 		Usage: "Freeform header field set by the miner",
 	}
 	// Account settings
@@ -162,7 +163,7 @@ var (
 		Usage: "Enables metrics reporting. When the value is a path, either relative or absolute, then a log is written to the respective file.",
 	}
 	FakePoWFlag = cli.BoolFlag{
-		Name:  "fakepow",
+		Name:  "fake-pow, fakepow",
 		Usage: "Disables proof-of-work verification",
 	}
 
@@ -172,36 +173,36 @@ var (
 		Usage: "Enable the HTTP-RPC server",
 	}
 	RPCListenAddrFlag = cli.StringFlag{
-		Name:  "rpcaddr",
+		Name:  "rpc-addr, rpcaddr",
 		Usage: "HTTP-RPC server listening interface",
 		Value: common.DefaultHTTPHost,
 	}
 	RPCPortFlag = cli.IntFlag{
-		Name:  "rpcport",
+		Name:  "rpc-port, rpcport",
 		Usage: "HTTP-RPC server listening port",
 		Value: common.DefaultHTTPPort,
 	}
 	RPCCORSDomainFlag = cli.StringFlag{
-		Name:  "rpccorsdomain",
+		Name:  "rpc-cors-domain, rpccorsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
 		Value: "",
 	}
 	RPCApiFlag = cli.StringFlag{
-		Name:  "rpcapi",
+		Name:  "rpc-api, rpcapi",
 		Usage: "API's offered over the HTTP-RPC interface",
 		Value: rpc.DefaultHTTPApis,
 	}
 	IPCDisabledFlag = cli.BoolFlag{
-		Name:  "ipcdisable",
+		Name:  "ipc-disable, ipcdisable",
 		Usage: "Disable the IPC-RPC server",
 	}
 	IPCApiFlag = cli.StringFlag{
-		Name:  "ipcapi",
+		Name:  "ipc-api, ipcapi",
 		Usage: "API's offered over the IPC-RPC interface",
 		Value: rpc.DefaultIPCApis,
 	}
 	IPCPathFlag = DirectoryFlag{
-		Name:  "ipc-path,ipcpath",
+		Name:  "ipc-path, ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 		Value: DirectoryString{common.DefaultIPCSocket},
 	}
@@ -210,22 +211,22 @@ var (
 		Usage: "Enable the WS-RPC server",
 	}
 	WSListenAddrFlag = cli.StringFlag{
-		Name:  "wsaddr",
+		Name:  "ws-addr, wsaddr",
 		Usage: "WS-RPC server listening interface",
 		Value: common.DefaultWSHost,
 	}
 	WSPortFlag = cli.IntFlag{
-		Name:  "wsport",
+		Name:  "ws-port, wsport",
 		Usage: "WS-RPC server listening port",
 		Value: common.DefaultWSPort,
 	}
 	WSApiFlag = cli.StringFlag{
-		Name:  "wsapi",
+		Name:  "ws-api, wsapi",
 		Usage: "API's offered over the WS-RPC interface",
 		Value: rpc.DefaultHTTPApis,
 	}
 	WSAllowedOriginsFlag = cli.StringFlag{
-		Name:  "wsorigins",
+		Name:  "ws-origins, wsorigins",
 		Usage: "Origins from which to accept websockets requests",
 		Value: "",
 	}
@@ -240,12 +241,12 @@ var (
 
 	// Network Settings
 	MaxPeersFlag = cli.IntFlag{
-		Name:  "maxpeers",
+		Name:  "max-peers, maxpeers",
 		Usage: "Maximum number of network peers (network disabled if set to 0)",
 		Value: 25,
 	}
 	MaxPendingPeersFlag = cli.IntFlag{
-		Name:  "maxpendpeers",
+		Name:  "max-pend-peers, maxpendpeers",
 		Usage: "Maximum number of pending connection attempts (defaults used if set to 0)",
 		Value: 0,
 	}
@@ -264,7 +265,7 @@ var (
 		Usage: "P2P node key file",
 	}
 	NodeKeyHexFlag = cli.StringFlag{
-		Name:  "nodekeyhex",
+		Name:  "nodekey-hex, nodekeyhex",
 		Usage: "P2P node key as hex (for testing)",
 	}
 	NATFlag = cli.StringFlag{
@@ -273,7 +274,7 @@ var (
 		Value: "any",
 	}
 	NoDiscoverFlag = cli.BoolFlag{
-		Name:  "nodiscover",
+		Name:  "no-discover, nodiscover",
 		Usage: "Disables the peer discovery mechanism (manual peer addition)",
 	}
 	WhisperEnabledFlag = cli.BoolFlag{
@@ -282,7 +283,7 @@ var (
 	}
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
-		Name:  "jspath",
+		Name:  "js-path, jspath",
 		Usage: "JavaScript root path for `loadScript` and document root for `admin.httpGet`",
 		Value: ".",
 	}
@@ -294,32 +295,32 @@ var (
 
 	// Gas price oracle settings
 	GpoMinGasPriceFlag = cli.StringFlag{
-		Name:  "gpomin",
+		Name:  "gpo-min, gpomin",
 		Usage: "Minimum suggested gas price",
 		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	GpoMaxGasPriceFlag = cli.StringFlag{
-		Name:  "gpomax",
+		Name:  "gpo-min, gpomin",
 		Usage: "Maximum suggested gas price",
 		Value: new(big.Int).Mul(big.NewInt(500), common.Shannon).String(),
 	}
 	GpoFullBlockRatioFlag = cli.IntFlag{
-		Name:  "gpofull",
+		Name:  "gpo-full, gpofull",
 		Usage: "Full block threshold for gas price calculation (%)",
 		Value: 80,
 	}
 	GpobaseStepDownFlag = cli.IntFlag{
-		Name:  "gpobasedown",
+		Name:  "gpo-base-down, gpobasedown",
 		Usage: "Suggested gas price base step down ratio (1/1000)",
 		Value: 10,
 	}
 	GpobaseStepUpFlag = cli.IntFlag{
-		Name:  "gpobaseup",
+		Name:  "gpo-base-up, gpobaseup",
 		Usage: "Suggested gas price base step up ratio (1/1000)",
 		Value: 100,
 	}
 	GpobaseCorrectionFactorFlag = cli.IntFlag{
-		Name:  "gpobasecf",
+		Name:  "gpo-base-cf, gpobasecf",
 		Usage: "Suggested gas price base correction factor (%)",
 		Value: 110,
 	}
@@ -332,13 +333,13 @@ var (
 // aliasableName check global vars for aliases flag and directoryFlag names.
 // These can be "comma,sep-arated", and ensures that if one is set (and/or not the other),
 // only one var will be returned and it will be decided in order of appearance.
-func aliasableName(commaSeparatedName string, ctx *cli.Context) (string) {
+func aliasableName(commaSeparatedName string, ctx *cli.Context) string {
 	names := strings.Split(commaSeparatedName, ",")
 	returnName := names[0] // first name as default
 	last := len(names) - 1
 	// for in reverse, so that we prioritize the first appearing
 	for i := last; i >= 0; i-- {
-		if ctx.GlobalIsSet(names[i]) {
+		if ctx.GlobalIsSet(strings.TrimSpace(names[i])) {
 			returnName = names[i]
 		}
 	}

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
+	"strings"
 )
 
 // These are all the command line flags we support.
@@ -22,7 +23,7 @@ import (
 var (
 	// General settings
 	DataDirFlag = DirectoryFlag{
-		Name:  "datadir",
+		Name:  "data-dir,datadir",
 		Usage: "Data directory for the databases and keystore",
 		Value: DirectoryString{common.DefaultDataDir()},
 	}
@@ -63,7 +64,7 @@ var (
 		Usage: "Enable NatSpec confirmation notice",
 	}
 	DocRootFlag = DirectoryFlag{
-		Name:  "docroot",
+		Name:  "doc-root,docroot",
 		Usage: "Document Root for HTTPClient file scheme",
 		Value: DirectoryString{common.HomeDir()},
 	}
@@ -200,7 +201,7 @@ var (
 		Value: rpc.DefaultIPCApis,
 	}
 	IPCPathFlag = DirectoryFlag{
-		Name:  "ipcpath",
+		Name:  "ipc-path,ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 		Value: DirectoryString{common.DefaultIPCSocket},
 	}
@@ -327,3 +328,19 @@ var (
 		Usage: "Use classic blockchain (always set, flag is unused and exists for compatibility only)",
 	}
 )
+
+// aliasableName check global vars for aliases flag and directoryFlag names.
+// These can be "comma,sep-arated", and ensures that if one is set (and/or not the other),
+// only one var will be returned and it will be decided in order of appearance.
+func aliasableName(commaSeparatedName string, ctx *cli.Context) (string) {
+	names := strings.Split(commaSeparatedName, ",")
+	returnName := names[0] // first name as default
+	last := len(names) - 1
+	// for in reverse, so that we prioritize the first appearing
+	for i := last; i >= 0; i-- {
+		if ctx.GlobalIsSet(names[i]) {
+			returnName = names[i]
+		}
+	}
+	return returnName
+}

--- a/cmd/geth/genesis.bats
+++ b/cmd/geth/genesis.bats
@@ -85,3 +85,19 @@ teardown() {
 	[[ "$output" == *'"0x0000000000000042"'* ]]
 }
 
+@test "check genesis default block hash mainnet" {
+	run $GETH_CMD --data-dir $DATA_DIR --exec 'eth.getBlock(0).hash' console
+	echo "$output"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"'* ]]
+}
+
+@test "check genesis default block hash testnet" {
+	run $GETH_CMD --testnet --data-dir $DATA_DIR --exec 'eth.getBlock(0).hash' console
+	echo "$output"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303"'* ]]
+}
+

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -220,7 +220,7 @@ the configuration of a chain database. It includes genesis block data as well as
 		// for chains with the main network genesis block and network id 1.
 		eth.EnableBadBlockReporting = true
 
-		gasLimit := ctx.GlobalString(aliasableName(TargetGasLimitFlag.Name, ctx))
+		gasLimit := TargetGasLimitFlag.Value
 		if _, ok := core.TargetGasLimit.SetString(gasLimit, 0); !ok {
 			log.Fatalf("malformed %s flag value %q", aliasableName(TargetGasLimitFlag.Name, ctx), gasLimit)
 		}
@@ -369,7 +369,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	accman := ethereum.AccountManager()
 	passwords := MakePasswordList(ctx)
 
-	accounts := strings.Split(ctx.GlobalString(aliasableName(UnlockedAccountFlag.Name, ctx)), ",")
+	accounts := strings.Split(UnlockedAccountFlag.Value, ",")
 	for i, account := range accounts {
 		if trimmed := strings.TrimSpace(account); trimmed != "" {
 			unlockAccount(ctx, accman, trimmed, i, passwords)
@@ -377,7 +377,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	}
 	// Start auxiliary services if enabled
 	if ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)) {
-		if err := ethereum.StartMining(ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)), ctx.GlobalString(aliasableName(MiningGPUFlag.Name, ctx))); err != nil {
+		if err := ethereum.StartMining(MinerThreadsFlag.Value, MiningGPUFlag.Value); err != nil {
 			log.Fatalf("Failed to start mining: ", err)
 		}
 	}
@@ -442,7 +442,7 @@ func version(ctx *cli.Context) error {
 	fmt.Println("Geth")
 	fmt.Println("Version:", Version)
 	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
-	fmt.Println("Network Id:", ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)))
+	fmt.Println("Network Id:", ctx.GlobalString(aliasableName(NetworkIdFlag.Name, ctx)))
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -220,7 +220,7 @@ the configuration of a chain database. It includes genesis block data as well as
 		// for chains with the main network genesis block and network id 1.
 		eth.EnableBadBlockReporting = true
 
-		gasLimit := TargetGasLimitFlag.Value
+		gasLimit := ctx.GlobalString(aliasableName(TargetGasLimitFlag.Name, ctx))
 		if _, ok := core.TargetGasLimit.SetString(gasLimit, 0); !ok {
 			log.Fatalf("malformed %s flag value %q", aliasableName(TargetGasLimitFlag.Name, ctx), gasLimit)
 		}
@@ -369,7 +369,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	accman := ethereum.AccountManager()
 	passwords := MakePasswordList(ctx)
 
-	accounts := strings.Split(UnlockedAccountFlag.Value, ",")
+	accounts := strings.Split(ctx.GlobalString(aliasableName(UnlockedAccountFlag.Name, ctx)), ",")
 	for i, account := range accounts {
 		if trimmed := strings.TrimSpace(account); trimmed != "" {
 			unlockAccount(ctx, accman, trimmed, i, passwords)
@@ -377,7 +377,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	}
 	// Start auxiliary services if enabled
 	if ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)) {
-		if err := ethereum.StartMining(MinerThreadsFlag.Value, MiningGPUFlag.Value); err != nil {
+		if err := ethereum.StartMining(ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)), ctx.GlobalString(aliasableName(MiningGPUFlag.Name, ctx))); err != nil {
 			log.Fatalf("Failed to start mining: ", err)
 		}
 	}
@@ -442,7 +442,7 @@ func version(ctx *cli.Context) error {
 	fmt.Println("Geth")
 	fmt.Println("Version:", Version)
 	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
-	fmt.Println("Network Id:", ctx.GlobalString(aliasableName(NetworkIdFlag.Name, ctx)))
+	fmt.Println("Network Id:", ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)))
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -67,9 +67,10 @@ func makeCLIApp() (app *cli.App) {
 		attachCommand,
 		javascriptCommand,
 		{
-			Action: makedag,
-			Name:   "makedag",
-			Usage:  "generate ethash dag (for testing)",
+			Action:  makedag,
+			Name:    "make-dag",
+			Aliases: []string{"makedag"},
+			Usage:   "generate ethash dag (for testing)",
 			Description: `
 The makedag command generates an ethash DAG in /tmp/dag.
 
@@ -78,17 +79,19 @@ Regular users do not need to execute it.
 `,
 		},
 		{
-			Action: gpuinfo,
-			Name:   "gpuinfo",
-			Usage:  "gpuinfo",
+			Action:  gpuinfo,
+			Name:    "gpu-info",
+			Aliases: []string{"gpuinfo"},
+			Usage:   "gpuinfo",
 			Description: `
 Prints OpenCL device info for all found GPUs.
 `,
 		},
 		{
-			Action: gpubench,
-			Name:   "gpubench",
-			Usage:  "benchmark GPU",
+			Action:  gpubench,
+			Name:    "gpu-bench",
+			Aliases: []string{"gpubench"},
+			Usage:   "benchmark GPU",
 			Description: `
 Runs quick benchmark on first GPU found.
 `,
@@ -104,7 +107,7 @@ The output of this command is supposed to be machine-readable.
 		{
 			Action: initGenesis,
 			Name:   "init",
-			Usage:  "bootstraps and initialises a new genesis block (JSON)",
+			Usage:  "bootstraps and initialises a new genesis block (JSON) [REQUIRED argument: filepath.json]",
 			Description: `
 The init command initialises a new genesis block and definition for the network.
 This is a destructive action and changes the network in which you will be
@@ -112,9 +115,10 @@ participating.
 `,
 		},
 		{
-			Action: dumpChainConfig,
-			Name:   "dumpChainConfig",
-			Usage:  "dump current chain configuration to JSON file [REQUIRED argument: filepath.json]",
+			Action:  dumpChainConfig,
+			Name:    "dump-chain-config",
+			Aliases: []string{"dumpchainconfig"},
+			Usage:   "dump current chain configuration to JSON file [REQUIRED argument: filepath.json]",
 			Description: `
 The dump external configuration command writes a JSON file containing pertinent configuration data for
 the configuration of a chain database. It includes genesis block data as well as chain fork settings.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -31,6 +31,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/ethereumproject/ethash"
+	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/ethereumproject/go-ethereum/console"
 	"github.com/ethereumproject/go-ethereum/core"
 	"github.com/ethereumproject/go-ethereum/eth"
@@ -39,7 +40,6 @@ import (
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/metrics"
 	"github.com/ethereumproject/go-ethereum/node"
-	"github.com/ethereumproject/go-ethereum/common"
 )
 
 // Version is the application revision identifier. It can be set with the linker
@@ -220,9 +220,9 @@ the configuration of a chain database. It includes genesis block data as well as
 		// for chains with the main network genesis block and network id 1.
 		eth.EnableBadBlockReporting = true
 
-		gasLimit := ctx.GlobalString(TargetGasLimitFlag.Name)
+		gasLimit := ctx.GlobalString(aliasableName(TargetGasLimitFlag.Name, ctx))
 		if _, ok := core.TargetGasLimit.SetString(gasLimit, 0); !ok {
-			log.Fatalf("malformed %s flag value %q", TargetGasLimitFlag.Name, gasLimit)
+			log.Fatalf("malformed %s flag value %q", aliasableName(TargetGasLimitFlag.Name, ctx), gasLimit)
 		}
 
 		return nil
@@ -241,7 +241,6 @@ the configuration of a chain database. It includes genesis block data as well as
 	}
 	return app
 }
-
 
 func main() {
 	app := makeCLIApp()
@@ -290,7 +289,6 @@ func initGenesis(ctx *cli.Context) error {
 	return nil
 }
 
-
 // dumpExternailChainConfig exports chain configuration based on database to JSON file
 func dumpChainConfig(ctx *cli.Context) error {
 
@@ -321,7 +319,7 @@ func dumpChainConfig(ctx *cli.Context) error {
 	//
 	// FYI: here would be an inflection point for if we used a --genesis flag.
 	if genesisDump == nil {
-		if ctx.GlobalBool(TestNetFlag.Name) {
+		if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 			glog.V(logger.Info).Info("WARNING: No genesis block found in database. Dumping the testnet default genesis.")
 			genesisDump = core.TestNetGenesis
 		} else {
@@ -356,7 +354,6 @@ func dumpChainConfig(ctx *cli.Context) error {
 	return nil
 }
 
-
 // startNode boots up the system node and all registered protocols, after which
 // it unlocks any requested accounts, and starts the RPC/IPC interfaces and the
 // miner.
@@ -372,15 +369,15 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	accman := ethereum.AccountManager()
 	passwords := MakePasswordList(ctx)
 
-	accounts := strings.Split(ctx.GlobalString(UnlockedAccountFlag.Name), ",")
+	accounts := strings.Split(ctx.GlobalString(aliasableName(UnlockedAccountFlag.Name, ctx)), ",")
 	for i, account := range accounts {
 		if trimmed := strings.TrimSpace(account); trimmed != "" {
 			unlockAccount(ctx, accman, trimmed, i, passwords)
 		}
 	}
 	// Start auxiliary services if enabled
-	if ctx.GlobalBool(MiningEnabledFlag.Name) {
-		if err := ethereum.StartMining(ctx.GlobalInt(MinerThreadsFlag.Name), ctx.GlobalString(MiningGPUFlag.Name)); err != nil {
+	if ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)) {
+		if err := ethereum.StartMining(ctx.GlobalInt(aliasableName(MinerThreadsFlag.Name, ctx)), ctx.GlobalString(aliasableName(MiningGPUFlag.Name, ctx))); err != nil {
 			log.Fatalf("Failed to start mining: ", err)
 		}
 	}
@@ -441,11 +438,11 @@ func gpubench(ctx *cli.Context) error {
 	return nil
 }
 
-func version(c *cli.Context) error {
+func version(ctx *cli.Context) error {
 	fmt.Println("Geth")
 	fmt.Println("Version:", Version)
 	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
-	fmt.Println("Network Id:", c.GlobalInt(NetworkIdFlag.Name))
+	fmt.Println("Network Id:", ctx.GlobalInt(aliasableName(NetworkIdFlag.Name, ctx)))
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -128,6 +128,7 @@ the configuration of a chain database. It includes genesis block data as well as
 		PasswordFileFlag,
 		BootnodesFlag,
 		DataDirFlag,
+		DocRootFlag,
 		UseChainConfigFlag,
 		KeyStoreDirFlag,
 		ChainIDFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -56,6 +56,8 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "ETHEREUM",
 		Flags: []cli.Flag{
 			DataDirFlag,
+			ChainIDFlag,
+			UseChainConfigFlag,
 			KeyStoreDirFlag,
 			NetworkIdFlag,
 			TestNetFlag,


### PR DESCRIPTION
Moves `--lowercasecommand` to `--lower-case-command`.

Retains original commands as "aliases" for backwards compatibility. 

Resolves #198.