### PR TITLE
do not clear logsBloom field with pending block

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -575,7 +575,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(blockNr rpc.BlockNumber, fullTx b
 		response, err := s.rpcOutputBlock(block, true, fullTx)
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "logsBloom", "miner"} {
+			for _, field := range []string{"hash", "nonce", "miner"} {
 				response[field] = nil
 			}
 		}


### PR DESCRIPTION
For some cases, a third party (eg. SmartPool) might want to get block header corresponding to last "pow-work" (returned by `eth_getWork`). The only potential way is using `eth_getBlockByNumber` with pending and recalculate the pow hash to see if it matches the hash returned from `eth_getWork`. Unfortunately, `eth_getBlockByNumber` always returns null for `logsBloom`, one field that is used to calculate `HashNoNonce`, so it is currently impossible to do so.

Right now, I don't really understand the reason behind setting logsBloom to null for pending block when it is useful to have logsBloom returned as I described above.

Note: This PR was also merged with EF's go-ethereum repository.