### PR TITLE
Fix chain config parsing interface{} bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Specifying the `--chain=morden` flag will reconfigure your Geth instance a bit:
  -  As mentioned above, Geth will host its testnet data in a `morden` subfolder (`~/.ethereum-classic/morden`).
  - Instead of connecting the main Ethereum network, the client will connect to the test network, which uses different P2P bootnodes, different network IDs and genesis states.
 
-You may also optionally use `--testnet` and `--chain=testnet` to enable this configuration. _All testnet configuration defaults will use the __/morden__ subdirectory, no matter which flags are used._ If you'd like to place testnet data in a custom subdirectory, please use an external chain configuration along with the `--chain-config my-custom-testnet.json` flag... for starters: simply copy _/config/testnet.json_ and change the "id" field.
+You may also optionally use `--testnet` and `--chain=testnet` to enable this configuration. If you'd like to use a custom data subdirectory with a testnet configuration use `--testnet --chain mycustomtestnet`.
 
 > *Note: Although there are some internal protective measures to prevent transactions from crossing over between the main network and test network (different starting nonces), you should make sure to always use separate accounts for play-money and real-money. Unless you manually move accounts, Geth
 will by default correctly separate the two networks and will not make any accounts available between them.*

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -764,6 +764,12 @@ func logChainConfiguration(ctx *cli.Context, config *core.SufficientChainConfig)
 		if !config.ChainConfig.Forks[i].RequiredHash.IsEmpty() {
 			glog.V(logger.Info).Info(fmt.Sprintf("         with block %v", config.ChainConfig.Forks[i].RequiredHash.Hex()))
 		}
+		for _, feat := range config.ChainConfig.Forks[i].Features {
+			glog.V(logger.Info).Infof("    id: %v", feat.ID)
+			for k, v := range feat.Options {
+				glog.V(logger.Info).Infof("        %v: %v", k, v)
+			}
+		}
 	}
 
 	glog.V(logger.Info).Info(glog.Separator("-"))
@@ -779,14 +785,7 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 		configName = "morden testnet"
 	}
 
-	genesis := core.GetBlock(db, core.GetCanonicalHash(db, 0))
-	genesisHash := ""
-	if genesis != nil {
-		genesisHash = genesis.Hash().Hex()
-	}
-	if genesisHash != "" {
-		glog.V(logger.Info).Info(fmt.Sprintf("Loading %v configuration from database with \x1b[36mgenesis\x1b[39m block \x1b[36m%s\x1b[39m.", configName, genesisHash))
-	}
+	glog.V(logger.Info).Info(fmt.Sprintf("Loading \x1b[36m%v\x1b[39m configuration from database...", configName))
 
 	return c
 }

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -765,9 +765,9 @@ func logChainConfiguration(ctx *cli.Context, config *core.SufficientChainConfig)
 			glog.V(logger.Info).Info(fmt.Sprintf("         with block %v", config.ChainConfig.Forks[i].RequiredHash.Hex()))
 		}
 		for _, feat := range config.ChainConfig.Forks[i].Features {
-			glog.V(logger.Info).Infof("    id: %v", feat.ID)
+			glog.V(logger.Debug).Infof("    id: %v", feat.ID)
 			for k, v := range feat.Options {
-				glog.V(logger.Info).Infof("        %v: %v", k, v)
+				glog.V(logger.Debug).Infof("        %v: %v", k, v)
 			}
 		}
 	}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereumproject/go-ethereum/core/types"
 	"github.com/ethereumproject/go-ethereum/ethdb"
+	"path/filepath"
 )
 
 func TestConfigErrorProperties(t *testing.T) {
@@ -287,6 +288,28 @@ func TestChainConfig_GetFeature4_WorkForHighNumbers(t *testing.T) {
 	highBlock := big.NewInt(99999999999999999)
 	if _, _, ok := c.GetFeature(highBlock, "difficulty"); !ok {
 		t.Errorf("unexpected unfound difficulty feature for far-future block: %v", highBlock)
+	}
+}
+
+func TestChainConfig_GetChainID(t *testing.T) {
+	if DefaultConfig.GetChainID().Cmp(DefaultChainConfigChainID) != 0 {
+		t.Error("got: %v, want: %v", DefaultConfig.GetChainID(), DefaultTestnetChainConfigChainID)
+	}
+	if TestConfig.GetChainID().Cmp(DefaultTestnetChainConfigChainID) != 0 {
+		t.Error("got: %v, want: %v", TestConfig.GetChainID(), DefaultTestnetChainConfigChainID)
+	}
+
+	// Test parsing default external config.
+	p, e := filepath.Abs("../cmd/geth/config/mainnet.json")
+	if e != nil {
+		t.Errorf("filepath err: %v", e)
+	}
+	extConfig, err := ReadExternalChainConfig(p)
+	if err != nil {
+		t.Errorf("could not find file: %v", err)
+	}
+	if extConfig.ChainConfig.GetChainID().Cmp(big.NewInt(61)) != 0 {
+		t.Error("found 0 chainid for eip155")
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -151,20 +151,15 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.GetChainID())
 
 	// Load up any custom genesis block if requested
 	if config.Genesis != nil {
-		block, err := core.WriteGenesisBlock(chainDb, config.Genesis)
+		_, err := core.WriteGenesisBlock(chainDb, config.Genesis)
 		if err != nil {
 			return nil, err
 		}
-		if fmt.Sprintf("%x", block.Hash()) == "0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303" {
-			glog.V(logger.Info).Infof("Successfully established morden testnet genesis block: %s", block.Hash().Hex())
-		} else {
-			glog.V(logger.Info).Infof("Successfully established custom genesis block: %s", block.Hash().Hex())
-		}
-
 	}
 
 	// Load up a test setup if directly injected
@@ -232,6 +227,15 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 			return nil, err
 		}
 		glog.V(logger.Info).Infof("Successfully wrote default ethereum mainnet genesis block: %s", genesis.Hash().Hex())
+	}
+
+	// Log genesis block information.
+	if fmt.Sprintf("%x", genesis.Hash()) == "0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303" {
+		glog.V(logger.Info).Infof("Successfully established morden testnet genesis block: \x1b[36m%s\x1b[39m", genesis.Hash().Hex())
+	} else if fmt.Sprintf("%x", genesis.Hash()) == "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" {
+		glog.V(logger.Info).Infof("Successfully established mainnet genesis block: \x1b[36m%s\x1b[39m", genesis.Hash().Hex())
+	} else {
+		glog.V(logger.Info).Infof("Successfully established custom genesis block: \x1b[36m%s\x1b[39m", genesis.Hash().Hex())
 	}
 
 	if config.ChainConfig == nil {


### PR DESCRIPTION
Also rearranges startup logging to dedupe genesis hash logs and updates README to reflect revised `--testnet` vs `--chain` usage.

Fixes #229 