### PR TITLE
eth/downloader: conform Downloader.cancel comments to its signature

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -507,8 +507,7 @@ func (d *Downloader) spawnSync(origin uint64, fetchers ...func() error) error {
 	return nil
 }
 
-// cancel cancels all of the operations and resets the queue. It returns true
-// if the cancel operation was completed.
+// cancel cancels all of the operations and resets the queue.
 func (d *Downloader) cancel() {
 	// Close the current cancel channel
 	d.cancelLock.Lock()


### PR DESCRIPTION
The signature for Downloader.cancel is
```go
func (d *Downloader) cancel()
```

yet the comment claims it returns true if the cancel operation
was completed.

Just a minor oversight, traceable back to commit
https://github.com/ethereumproject/go-ethereum/commit/fc7abd98865f3bdc6cc36258026db98a649cd577#diff-c2fa15e758e986688c646459d8970a50L310
in which the signature was changed but the comment wasn't.