### PR TITLE
create '--log-dir' flag to specify directory for logging

### DIFF
--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
+	"path/filepath"
 )
 
 // These are all the command line flags we support.
@@ -152,6 +153,11 @@ var (
 		Name:  "vmodule",
 		Usage: "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=6,p2p=5)",
 		Value: glog.GetVModule(),
+	}
+	LogDirFlag = DirectoryFlag{
+		Name: "log-dir,logdir",
+		Usage: "Directory in which to write log files",
+		Value: DirectoryString{filepath.Join(common.DefaultDataDir(), "logs")},
 	}
 	BacktraceAtFlag = cli.GenericFlag{
 		Name:  "backtrace",

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -158,6 +158,7 @@ The output of this command is supposed to be machine-readable.
 		RPCCORSDomainFlag,
 		VerbosityFlag,
 		VModuleFlag,
+		LogDirFlag,
 		BacktraceAtFlag,
 		MetricsFlag,
 		FakePoWFlag,
@@ -193,7 +194,15 @@ The output of this command is supposed to be machine-readable.
 		runtime.GOMAXPROCS(runtime.NumCPU())
 
 		glog.CopyStandardLogTo("INFO")
-		glog.SetToStderr(true)
+		if ctx.GlobalIsSet(aliasableName(LogDirFlag.Name, ctx)) {
+			if p := ctx.GlobalString(aliasableName(LogDirFlag.Name, ctx)); p != "" {
+
+				// TODO: check for dir exist, exit fatal if not.
+
+				glog.SetLogDir(p)
+			}
+		}
+		//glog.SetToStderr(true) // I don't know why...
 
 		if s := ctx.String("metrics"); s != "" {
 			go metrics.Collect(s)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -194,15 +194,19 @@ The output of this command is supposed to be machine-readable.
 		runtime.GOMAXPROCS(runtime.NumCPU())
 
 		glog.CopyStandardLogTo("INFO")
+
 		if ctx.GlobalIsSet(aliasableName(LogDirFlag.Name, ctx)) {
+
 			if p := ctx.GlobalString(aliasableName(LogDirFlag.Name, ctx)); p != "" {
-
-				// TODO: check for dir exist, exit fatal if not.
-
+				// mkdir -p /path/to/log_dir
+				if e := os.MkdirAll(p, os.ModePerm); e != nil {
+					return e
+				}
 				glog.SetLogDir(p)
 			}
+		} else {
+			glog.SetToStderr(true) // I don't know why...
 		}
-		//glog.SetToStderr(true) // I don't know why...
 
 		if s := ctx.String("metrics"); s != "" {
 			go metrics.Collect(s)

--- a/logger/glog/glog_file.go
+++ b/logger/glog/glog_file.go
@@ -38,6 +38,9 @@ var logDirs []string
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
 //var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+
+
+
 var logDir *string = new(string)
 
 func SetLogDir(str string) {


### PR DESCRIPTION
Creates flag for existing functionality provided by `glog` logger. 
If flag is set and value not specified, the default is `<EthereumClassic>/logs`.
If directory value for enabled flag is not yet existing, it will be created.

Geth by defaults logs to `stderr`, making required redirection `2>`, which is atypical. I don't know why it does that but there's probably a good reason. This functionality is unchanged.

This one's for you, @r8d8.