### PR TITLE
`attach` command should use chain directory schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,28 @@ __Legend__:
 
 Releases considered stable may be found on our [Releases Page](https://github.com/ethereumproject/go-ethereum/releases).
 
-## [3.5.0]
+## [Unreleased]
+
+
+## [3.5.0] - 2017-06-02
+
+Wiki: https://github.com/ethereumproject/go-ethereum/wiki/Release-3.5.0-Notes
+
 #### Added
 - _Option_: `--index-accounts` - use persistent keystore key file indexing (recommended for use with greater than ~10k-100k+ key files)
 - _Command_: `--index-accounts account index` - build or rebuild persisent key file index
 - _Option_: `--log-dir` - specify directory in which to redirect logs to files
+- _Command: `status` - retrieve contextual status for node, ethereum, and chain configuration
 #### Changed
 - _Command_: `dump <blockHash|blockNum>,<|blockHash|blockNum> <|address>,<|address>` - specify dump for _n_ block(s) for optionally _a_ address(es)
 - _Option__: `--chain` replaces `--chain-config` and expects consistent custom external chain config JSON path
 #### Fixed
 - SIGSEGV crash on malformed ChainID signer for replay-protected blocks.
 - Hash map exploit opportunity (thanks @karalabe)
+#### Removed
+- _Option_: `--chain-config`, replaced by `--chain`
 
-## [3.4.0] - 2017-05-15
-Tagged commit: c18792d
+## [3.4.0] - 2017-05-15 - c18792d
 
 Wiki: https://github.com/ethereumproject/go-ethereum/wiki/Release-3.4.0-Notes
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The external chain configuration file specifies valid settings for the following
 | `chainID` |  Chain identity. Determines local __/subdir__ for chain data, with required `chain.json` located in it. It is required, but must not be identical for each node. Please note that this is _not_ the chainID validation introduced in _EIP-155_; that is configured as a protocal upgrade within `forks.features`. |
 | `name` | Human readable name, ie _Ethereum Classic Mainnet_, _Morden Testnet._ |
 | `genesis` | Determines __genesis state__. If running the node for the first time, it will write the genesis block. If configuring an existing chain database with a different genesis block, it will overwrite it. |
-| `forks` | Determines configuration for fork-based __protocol upgrades__, ie _EIP-150_, _EIP-155_, _EIP-160_, _ECIP-1010_, etc ;-). |
+| `chainConfig` | Determines configuration for fork-based __protocol upgrades__, ie _EIP-150_, _EIP-155_, _EIP-160_, _ECIP-1010_, etc ;-). Subkeys are `forks` and `badHashes`. |
 | `bootstrap` | Determines __bootstrap nodes__ in [enode format](https://github.com/ethereumproject/wiki/wiki/enode-url-format). |
 
 

--- a/cmd/geth/boot.go
+++ b/cmd/geth/boot.go
@@ -31,6 +31,7 @@ var HomesteadBootNodes = []*discover.Node{
 	discover.MustParseNode("enode://5cd218959f8263bc3721d7789070806b0adff1a0ed3f95ec886fb469f9362c7507e3b32b256550b9a7964a23a938e8d42d45a0c34b332bfebc54b29081e83b93@35.187.57.94:30303"),    //boot3.etcdevteam.com
 	discover.MustParseNode("enode://39abab9d2a41f53298c0c9dc6bbca57b0840c3ba9dccf42aa27316addc1b7e56ade32a0a9f7f52d6c5db4fe74d8824bcedfeaecf1a4e533cacb71cf8100a9442@144.76.238.49:30303"),   //whysoserious-1
 	discover.MustParseNode("enode://f50e675a34f471af2438b921914b5f06499c7438f3146f6b8936f1faeb50b8a91d0d0c24fb05a66f05865cd58c24da3e664d0def806172ddd0d4c5bdbf37747e@144.76.238.49:30306"),   //whysoserious-2
+	discover.MustParseNode("enode://6dd3ac8147fa82e46837ec8c3223d69ac24bcdbab04b036a3705c14f3a02e968f7f1adfcdb002aacec2db46e625c04bf8b5a1f85bb2d40a479b3cc9d45a444af@104.237.131.102:30303"),
 }
 
 // TestNetBootNodes are the enode URLs of the P2P bootstrap nodes running on the
@@ -40,4 +41,7 @@ var TestNetBootNodes = []*discover.Node{
 	discover.MustParseNode("enode://afdc6076b9bf3e7d3d01442d6841071e84c76c73a7016cb4f35c0437df219db38565766234448f1592a07ba5295a867f0ce87b359bf50311ed0b830a2361392d@104.154.136.117:30403"), //boot1.etcdevteam.com
 	discover.MustParseNode("enode://21101a9597b79e933e17bc94ef3506fe99a137808907aa8fefa67eea4b789792ad11fb391f38b00087f8800a2d3dff011572b62a31232133dd1591ac2d1502c8@104.198.71.200:30403"),  //boot2.etcdevteam.com
 	discover.MustParseNode("enode://fd008499e9c4662f384b3cff23438879d31ced24e2d19504c6389bc6da6c882f9c2f8dbed972f7058d7650337f54e4ba17bb49c7d11882dd1731d26a6e62e3cb@35.187.57.94:30304"),    //boot3.etcdevteam.com
+	discover.MustParseNode("enode://30a1fd71f28aa6f66fe662af9ecc75f0a6980f06b71598f2b19d3dda04223fc0e53b47e40c9171d5014e9f5b59d9954de125782da592f5d95ea39066e2591d5d@104.237.131.102:30304"),
+	discover.MustParseNode("enode://7909d51011d8a153351169f21d3a7bbedb3be1e17d38c1f2fad06504dd5aa07a00f00845835d535fe702bf379c4d7209a51f4d1b723e0ca8b8732bd21fba3b30@139.162.133.42:30303"),
+	discover.MustParseNode("enode://a088dfb2f5305be9232e8071c5535f13718a4017e247a0b35074b807d43d99e022880c27302cdb5b1e98ad34c083dbbb483f2b17bdc66149bad037154d6ace96@139.162.127.72:30303"),
 }

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -101,7 +101,8 @@ func localConsole(ctx *cli.Context) error {
 // console to it.
 func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running geth instance and start the JavaScript console
-	var uri = "ipc:" + node.DefaultIPCEndpoint()
+	chainDir := MustMakeChainDataDir(ctx)
+	var uri = "ipc:" + node.DefaultIPCEndpoint(chainDir)
 	if ctx.Args().Present() {
 		uri = ctx.Args().First()
 	}
@@ -111,7 +112,7 @@ func remoteConsole(ctx *cli.Context) error {
 	}
 
 	config := console.Config{
-		DataDir: MustMakeChainDataDir(ctx),
+		DataDir: chainDir,
 		DocRoot: ctx.GlobalString(JSpathFlag.Name),
 		Client:  client,
 		Preload: MakeConsolePreloads(ctx),

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -31,12 +31,14 @@ import (
 	"github.com/ethereumproject/go-ethereum/rpc"
 	"github.com/gizak/termui"
 	"gopkg.in/urfave/cli.v1"
+	"github.com/ethereumproject/go-ethereum/common"
+	"path/filepath"
 )
 
 var (
 	monitorCommandAttachFlag = cli.StringFlag{
 		Name:  "attach",
-		Value: "ipc:" + node.DefaultIPCEndpoint(),
+		Value: "ipc:" + node.DefaultIPCEndpoint(filepath.Join(common.DefaultDataDir(), "mainnet")),
 		Usage: "API endpoint to attach to",
 	}
 	monitorCommandRowsFlag = cli.IntFlag{
@@ -69,7 +71,12 @@ to display multiple metrics simultaneously.
 // monitor starts a terminal UI based monitoring tool for the requested metrics.
 func monitor(ctx *cli.Context) error {
 	// Attach to an Ethereum node over IPC or RPC
-	client, err := rpc.NewClient(ctx.String(monitorCommandAttachFlag.Name))
+	endpoint := ctx.String(monitorCommandAttachFlag.Name)
+	// Set defaults (no arg value) to chain contextual path (via --chain or --testnet, since default val is mainnet)
+	if ctx.GlobalString(monitorCommandAttachFlag.Name) == "" {
+		endpoint = "ipc:" + node.DefaultIPCEndpoint(MustMakeChainDataDir(ctx))
+	}
+	client, err := rpc.NewClient(endpoint)
 	if err != nil {
 		log.Fatal("attach to remote geth: ", err)
 	}

--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/node"
 	"github.com/ethereumproject/go-ethereum/tests"
 	"github.com/ethereumproject/go-ethereum/whisper"
+	"path/filepath"
 )
 
 // Version is the application revision identifier. It can be set with the linker
@@ -105,7 +106,7 @@ func main() {
 func MakeSystemNode(keydir string, privkey string, test *tests.BlockTest) (*node.Node, error) {
 	// Create a networkless protocol stack
 	stack, err := node.New(&node.Config{
-		IPCPath:     node.DefaultIPCEndpoint(),
+		IPCPath:     node.DefaultIPCEndpoint(filepath.Join(common.DefaultDataDir(), "mainnet")),
 		HTTPHost:    common.DefaultHTTPHost,
 		HTTPPort:    common.DefaultHTTPPort,
 		HTTPModules: []string{"admin", "db", "eth", "debug", "miner", "net", "shh", "txpool", "personal", "web3"},

--- a/node/config.go
+++ b/node/config.go
@@ -54,7 +54,7 @@ type Config struct {
 	DataDir string
 
 	// IPCPath is the requested location to place the IPC endpoint. If the path is
-	// a simple file name, it is placed inside the data directory (or on the root
+	// a simple file name, it is placed inside the chaindata directory (or on the root
 	// pipe path on Windows), whereas if it's a resolvable path name (absolute or
 	// relative), then that specific path is enforced. An empty path disables IPC.
 	IPCPath string
@@ -163,8 +163,8 @@ func (c *Config) IPCEndpoint() string {
 }
 
 // DefaultIPCEndpoint returns the IPC path used by default.
-func DefaultIPCEndpoint() string {
-	config := &Config{DataDir: common.DefaultDataDir(), IPCPath: common.DefaultIPCSocket}
+func DefaultIPCEndpoint(chainDir string) string {
+	config := &Config{DataDir: chainDir, IPCPath: common.DefaultIPCSocket}
 	return config.IPCEndpoint()
 }
 


### PR DESCRIPTION
... by default.

Created `geth.ipc` already lives in `/mainnet/`, so `attach` should look in `/mainnet/geth.ipc`, likewise for `--chain=morden|CUSTOM`. Command still accepts `ipc:path/to/geth.ipc` as an optional argument.

Also updates CHANGELOG and README with typos/corrections.