### PR TITLE
api: add debug_AccountExist that checks whether an account exists

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -1622,6 +1622,19 @@ func (api *PublicDebugAPI) DumpBlock(number uint64) (state.Dump, error) {
 	return stateDb.RawDump([]common.Address{}), nil
 }
 
+// AccountExist checks whether an address is considered exists at a given block.
+func (api *PublicDebugAPI) AccountExist(address common.Address, number uint64) (bool, error) {
+	block := api.eth.BlockChain().GetBlockByNumber(number)
+	if block == nil {
+		return false, fmt.Errorf("block #%d not found", number)
+	}
+	stateDb, err := api.eth.BlockChain().StateAt(block.Root())
+	if err != nil {
+		return false, err
+	}
+	return stateDb.Exist(address), nil
+}
+
 // GetBlockRlp retrieves the RLP encoded for of a single block.
 func (api *PublicDebugAPI) GetBlockRlp(number uint64) (string, error) {
 	block := api.eth.BlockChain().GetBlockByNumber(number)


### PR DESCRIPTION
Even when an account has zero balance, nonce and no code, it might
still be considered existing due to CALL/CALLCODE/message call
transactions with zero value transfer, or CREATE/contract creation
transactions with no code deposit and zero value transfer.

Whether an account exists affects the gas cost. So this at least
affects EVM projects like SputnikVM who wants to run regression tests
using JSON-RPC.

See https://github.com/ethereumproject/sputnikvm/issues/206 for a related bug.