### PR TITLE
bugfix: Geth cannot handle replay-protected transaction

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -285,6 +285,14 @@ func (self *TxPool) add(tx *types.Transaction) error {
 	if self.pending[hash] != nil {
 		return fmt.Errorf("Known transaction (%x)", hash[:4])
 	}
+
+	// Set transaction signer according to the TxPool.
+	// Otherwise the 'From' field of the transaction cannot be
+	// extracted correctly when EIP-155 is enabled.
+	if tx.Protected() {
+		tx.SetSigner(self.signer)
+	}
+
 	err := self.validateTx(tx)
 	if err != nil {
 		return err


### PR DESCRIPTION
While creating a new Transaction it uses a hard code BasicSigner as the transaction's signer. However, if EIP-155 is applied and a replay-protected transaction is submited, Geth cannot handle it because the transaction's 'From' field can't be extracted correctly with BasicSigner.

