### PR TITLE
fix: the raw transaction signed by 'ChainIDSigner' doesn't be mined

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -235,6 +235,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		return err
 	}
 
+	if !pool.signer.Equal(tx.Signer()) {
+		return ErrInvalidSender
+	}
 	from, err := types.Sender(pool.signer, tx)
 	if err != nil {
 		return ErrInvalidSender

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -98,6 +98,10 @@ func NewTransaction(nonce uint64, to common.Address, amount, gasLimit, gasPrice 
 	return &Transaction{signer: BasicSigner{}, data: d}
 }
 
+func (tx *Transaction) Signer() Signer {
+	return tx.signer
+}
+
 func (tx *Transaction) SetSigner(s Signer) {
 	tx.signer = s
 }
@@ -116,13 +120,22 @@ func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &tx.data)
 }
 
+// DeriveSigner makes a *best* guess about which signer to use.
+func deriveSigner(V *big.Int) Signer {
+	if V.Sign() != 0 && isProtectedV(V) {
+		return NewChainIdSigner(deriveChainId(V))
+	} else {
+		return BasicSigner{}
+	}
+}
+
 func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 	_, size, _ := s.Kind()
 	err := s.Decode(&tx.data)
 	if err == nil {
 		tx.size.Store(common.StorageSize(rlp.ListSize(size)))
 	}
-	tx.signer = BasicSigner{}
+	tx.signer = deriveSigner(tx.data.V)
 	return err
 }
 


### PR DESCRIPTION
Hi, @woodywang and I are colleagues, both working in Huobi. As my colleague said, recently we found the transaction, which was signed by 'ChainIDSigner'([EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)) and broadcast through RPC 'SendRawTransaction',  would not be included in a certain block. The direct reason cause that is it was remove in function 'validatePool'.
However, my solution differs from @woodywang . I prefer to set the original signer for the transaction decoded from raw transaction and check the signer before queueing the transaction.