### PR TITLE
fix: the raw transaction signed by 'ChainIDSigner' doesn't be mined

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -235,6 +235,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		return err
 	}
 
+	if !pool.signer.Equal(tx.Signer()) {
+		return ErrInvalidSender
+	}
 	from, err := types.Sender(pool.signer, tx)
 	if err != nil {
 		return ErrInvalidSender


### PR DESCRIPTION
Hi, team. @woodywang and I are colleagues, both working in Huobi. As my colleague said, recently we found the transaction, which was signed by 'ChainIDSigner'([EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)) and broadcast through RPC 'SendRawTransaction',  would not be included in a certain block. The direct reason cause that is it was remove in function 'validatePool'.
However, my solution differs from @woodywang . I prefer to set the original signer for the transaction decoded from raw transaction and check the signer before queueing the transaction.
BTW, here is my colleague's PR: #293