### PR TITLE
problem: appveyor fails to deploy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,13 @@ build_script:
 artifacts:
   - path: '*.zip'
     name: geth
+before_deploy:
+  # Set up GCP upload.
+  - nuget install secure-file -ExcludeVersion
+  - secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
 deploy_script:
   - ps: >-
       If ($env:APPVEYOR_REPO_BRANCH -eq 'master') {
-        janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./gcloud-appveyor.json.enc"
+        janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
       }
+


### PR DESCRIPTION
either because of wrong gcloud-appveyor.json.enc file or because openssl cli not available

solution: install and use secure-file tool to decrypt prior to uploading