### PR TITLE
Fix: logging  not-found node is misleading

### DIFF
--- a/p2p/discover/database.go
+++ b/p2p/discover/database.go
@@ -180,7 +180,7 @@ func (db *nodeDB) storeInt64(key []byte, n int64) error {
 func (db *nodeDB) node(id NodeID) *Node {
 	blob, err := db.lvl.Get(makeKey(id, nodeDBDiscoverRoot), nil)
 	if err != nil {
-		glog.V(logger.Detail).Infof("failed to retrieve node %v: %v", id, err)
+		glog.V(logger.Detail).Infof("node does not exist in database: %v: %v", id, err)
 		return nil
 	}
 	node := new(Node)


### PR DESCRIPTION
This is a very common 'error' occurring when a given node is as-of-yet unknown,
and does not necessarily reflect an invalid or otherwise problematic node.

Fixes #308

Changes from 
```
failed to retrieve node
```
to: 
```
node does not exist in database:
```

This happens in the context of p2p node parsing:
```
I0720 15:32:30.343582 p2p/discover/table.go:471] Bonding 8c327816cc9e8f20: known=false, fails=0 age=416828h32m30.34357842s
I0720 15:32:30.343835 p2p/discover/database.go:183] failed to retrieve node 2e20b28392171e5b5bdcacca73a9c0a68c1bf20bfb4b84f1e0b47a061c3cedba1aa57e8ecca5e5e6ef9b24d65c664f53e00c910cf0cad59af3021c08def002b7: leveldb: not found
```

If you've got other suggestions for wording, they would be happily considered...
