### PR TITLE
p2p: good will assumption for the DAO fork (2)

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -46,8 +46,6 @@ var (
 
 	ErrHashKnownBad  = errors.New("known bad hash")
 	ErrHashKnownFork = validateError("known fork hash mismatch")
-
-	ErrHashEmpty = errors.New("empty hash")
 )
 
 // SufficientChainConfig holds necessary data for externalizing a given blockchain configuration.
@@ -336,7 +334,7 @@ func (c *ChainConfig) GetFeature(num *big.Int, id string) (*ForkFeature, *Fork, 
 
 func (c *ChainConfig) HeaderCheck(h *types.Header) error {
 	if (h == &types.Header{}) {
-		return ErrHashEmpty
+		return nil
 	}
 
 	for _, fork := range c.Forks {

--- a/core/config.go
+++ b/core/config.go
@@ -46,6 +46,8 @@ var (
 
 	ErrHashKnownBad  = errors.New("known bad hash")
 	ErrHashKnownFork = validateError("known fork hash mismatch")
+
+	ErrHashEmpty = errors.New("empty hash")
 )
 
 // SufficientChainConfig holds necessary data for externalizing a given blockchain configuration.
@@ -333,6 +335,10 @@ func (c *ChainConfig) GetFeature(num *big.Int, id string) (*ForkFeature, *Fork, 
 }
 
 func (c *ChainConfig) HeaderCheck(h *types.Header) error {
+	if (h == &types.Header{}) {
+		return ErrHashEmpty
+	}
+
 	for _, fork := range c.Forks {
 		if fork.Block.Cmp(h.Number) != 0 {
 			continue

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -286,7 +286,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		}
 		if !fork.RequiredHash.IsEmpty() {
 			// Request the peer's fork block header for extra-dat
-			if err := p.RequestHeadersByNumber(fork.Block.Uint64(), 1, 0, false); err != nil {
+			if err := p.RequestHeadersByNumber(fork.Block.Uint64(), 1, 0, false); err != nil && err != core.ErrHashEmpty {
 				glog.V(logger.Warn).Infof("%v: error requesting headers by number ", p)
 				return err
 			}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -67,6 +67,7 @@ type peer struct {
 
 	knownTxs    *set.Set // Set of transaction hashes known to be known by this peer
 	knownBlocks *set.Set // Set of block hashes known to be known by this peer
+	knownHeaders *set.Set // Set of header hashes known to be known by this peer
 }
 
 func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {
@@ -79,6 +80,7 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {
 		id:          fmt.Sprintf("%x", id[:8]),
 		knownTxs:    set.New(),
 		knownBlocks: set.New(),
+		knownHeaders: set.New(),
 	}
 }
 
@@ -130,6 +132,19 @@ func (p *peer) MarkTransaction(hash common.Hash) {
 		p.knownTxs.Pop()
 	}
 	p.knownTxs.Add(hash)
+}
+
+// MarkHeader sets a header's hash as known for the peer, allowing us
+// to not have to redundantly request it again for fork checks.
+func (p *peer) MarkHeader(hash common.Hash) {
+	if !p.HasKnownHeader(hash) {
+		p.knownHeaders.Add(hash)
+	}
+}
+
+// HasKnownHeader check if a given header is already known for the peer.
+func (p *peer) HasKnownHeader(hash common.Hash) bool {
+	return p.knownHeaders.Has(hash)
 }
 
 // SendTransactions sends transactions to the peer and includes the hashes

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -307,6 +307,7 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 			} else if err != io.EOF {
 				glog.V(logger.Detail).Infof("%v: Protocol %s/%d error: %v\n", p, proto.Name, proto.Version, err)
 			}
+
 			p.protoErr <- err
 			p.wg.Done()
 		}()


### PR DESCRIPTION
Creates new `ErrHashEmpty` error which is returned by `core.HeaderCheck` if it receives empty `[]*types.Header`, and that specific error is ignored by `eth/handler.go`.

This is presented as a possible alternative/+addition to @sorpaas's changes in #313. 

Rel #309