### PR TITLE
cmd/geth:fix: invalid external chain config error is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ The external chain configuration file specifies valid settings for the following
 | `consensus` | _Optional_. Proof of work algorithm to use, either "ethash" or "ethast-test" (for development) |
 | `genesis` | Determines __genesis state__. If running the node for the first time, it will write the genesis block. If configuring an existing chain database with a different genesis block, it will overwrite it. |
 | `chainConfig` | Determines configuration for fork-based __protocol upgrades__, ie _EIP-150_, _EIP-155_, _EIP-160_, _ECIP-1010_, etc ;-). Subkeys are `forks` and `badHashes`. |
-| `bootstrap` | Determines __bootstrap nodes__ in [enode format](https://github.com/ethereumproject/wiki/wiki/enode-url-format). |
+| `bootstrap` | _Optional_. Determines __bootstrap nodes__ in [enode format](https://github.com/ethereumproject/wiki/wiki/enode-url-format). |
 
 
-*Fields `name`, `state.startingNonce`, and `consensus` are optional. Geth will panic if any required field is missing, invalid, or in conflict with another flag. This renders `--chain` __incompatible__ with `--bootnodes`, and `--testnet`. It remains __compatible__ with `--data-dir`.*
+*Fields `name`, `state.startingNonce`, and `consensus` are optional. Geth will panic if any required field is missing, invalid, or in conflict with another flag. This renders `--chain` __incompatible__ with `--testnet`. It remains __compatible__ with `--data-dir`.*
 
 To learn more about external chain configuration, please visit the [External Command Line Options Wiki page](https://github.com/ethereumproject/go-ethereum/wiki/Command-Line-Options).
 

--- a/cmd/geth/chainconfig.bats
+++ b/cmd/geth/chainconfig.bats
@@ -261,14 +261,14 @@ teardown() {
 	[[ "$output" == *"invalid flag or context value: used redundant/conflicting flags"* ]]
 }
 
-@test "--chain kitty --bootnodes=enode://e809c4a2fec7daed400e5e28564e23693b23b2cc5a019b612505631bbe7b9ccf709c1796d2a3d29ef2b045f210caf51e3c4f5b6d3587d43ad5d6397526fa6179@174.112.32.157:30303 | exit !=0" {
+@test "--chain kitty --bootnodes=enode://e809c4a2fec7daed400e5e28564e23693b23b2cc5a019b612505631bbe7b9ccf709c1796d2a3d29ef2b045f210caf51e3c4f5b6d3587d43ad5d6397526fa6179@174.112.32.157:30303 | exit 0" {
 	mkdir -p $DATA_DIR/kitty
 	cp $BATS_TEST_DIRNAME/../../cmd/geth/config/mainnet.json $DATA_DIR/kitty/chain.json
 	sed -i.bak s/mainnet/kitty/ $DATA_DIR/kitty/chain.json
 	run $GETH_CMD --data-dir $DATA_DIR --chain kitty --bootnodes=enode://e809c4a2fec7daed400e5e28564e23693b23b2cc5a019b612505631bbe7b9ccf709c1796d2a3d29ef2b045f210caf51e3c4f5b6d3587d43ad5d6397526fa6179@174.112.32.157:30303 console
 	echo "$output"
-	[ "$status" -ne 0 ]
-	[[ "$output" == *"Conflicting custom chain config and --bootnodes flags. Please use either but not both."* ]]
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"WARNING"* ]]
 }
 
 # Test fails to load invalid chain configuration from testdata/ JSON file.

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -161,10 +161,10 @@ func mustMakeChainIdentity(ctx *cli.Context) string {
 
 		// Check if passed arg exists as a path to a valid config file.
 		if fstat, ferr := os.Stat(filepath.Clean(chainFlagVal)); ferr == nil && !fstat.IsDir() {
-			glog.V(logger.Detail).Infof("Found existing file at --%v: %v", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
+			glog.V(logger.Debug).Infof("Found existing file at --%v: %v", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
 			c, configurationError := core.ReadExternalChainConfig(filepath.Clean(chainFlagVal))
 			if configurationError == nil {
-				glog.V(logger.Detail).Infof("OK: Valid chain configuration. Chain identity: %v", c.Identity)
+				glog.V(logger.Debug).Infof("OK: Valid chain configuration. Chain identity: %v", c.Identity)
 				if e := copyChainConfigFileToChainDataDir(ctx, c.Identity, filepath.Clean(chainFlagVal)); e != nil {
 					glog.Fatalf("Could not copy chain configuration: %v", e)
 				}
@@ -173,7 +173,7 @@ func mustMakeChainIdentity(ctx *cli.Context) string {
 			glog.Fatalf("Invalid chain config file at --%v: '%v': %v \nAssuming literal identity argument.",
 				aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal, configurationError)
 		}
-		glog.V(logger.Detail).Infof("No existing file at --%v: '%v'.", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
+		glog.V(logger.Debug).Infof("No existing file at --%v: '%v'. Using literal chain identity.", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
 		return chainFlagVal
 	} else if ctx.GlobalIsSet(aliasableName(ChainIdentityFlag.Name, ctx)) {
 		glog.Fatalf("%v: %v: chainID empty", ErrInvalidFlag, ErrInvalidChainID)

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -162,16 +162,16 @@ func mustMakeChainIdentity(ctx *cli.Context) string {
 		// Check if passed arg exists as a path to a valid config file.
 		if fstat, ferr := os.Stat(filepath.Clean(chainFlagVal)); ferr == nil && !fstat.IsDir() {
 			glog.V(logger.Detail).Infof("Found existing file at --%v: %v", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
-			c, e := core.ReadExternalChainConfig(filepath.Clean(chainFlagVal))
-			if e == nil {
+			c, configurationError := core.ReadExternalChainConfig(filepath.Clean(chainFlagVal))
+			if configurationError == nil {
 				glog.V(logger.Detail).Infof("OK: Valid chain configuration. Chain identity: %v", c.Identity)
 				if e := copyChainConfigFileToChainDataDir(ctx, c.Identity, filepath.Clean(chainFlagVal)); e != nil {
-					glog.Fatalf("Could not establish chain configuration: %v", e)
+					glog.Fatalf("Could not copy chain configuration: %v", e)
 				}
 				return c.Identity
 			}
-			glog.V(logger.Debug).Infof("Invalid chain config file at --%v: '%v': %v \nAssuming literal identity argument.",
-				aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal, e)
+			glog.Fatalf("Invalid chain config file at --%v: '%v': %v \nAssuming literal identity argument.",
+				aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal, configurationError)
 		}
 		glog.V(logger.Detail).Infof("No existing file at --%v: '%v'.", aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
 		return chainFlagVal

--- a/core/config.go
+++ b/core/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/logger"
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/p2p/discover"
+	"strings"
 )
 
 var (
@@ -195,10 +196,6 @@ func (c *SufficientChainConfig) IsValid() (string, bool) {
 
 	if cid := c.ChainConfig.GetChainID(); cid.Cmp(new(big.Int)) == 0 {
 		return "diehard chainid", false
-	}
-
-	if c.Bootstrap == nil || len(c.Bootstrap) == 0 {
-		return "bootstrap", false
 	}
 
 	return "", true
@@ -457,6 +454,10 @@ func ParseBootstrapNodeStrings(nodeStrings []string) []*discover.Node {
 	bootnodes := []*discover.Node{}
 
 	for _, url := range nodeStrings {
+		url = strings.TrimSpace(url)
+		if url == "" {
+			continue
+		}
 		node, err := discover.ParseNode(url)
 		if err != nil {
 			glog.V(logger.Error).Infof("Bootstrap URL %s: %v\n", url, err)

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -591,9 +591,9 @@ func TestSufficientChainConfig_IsValid(t *testing.T) {
 			scc.ChainConfig = oo
 
 			ooo := scc.Bootstrap
-			scc.Bootstrap = nil
-			if s, ok := scc.IsValid(); ok {
-				t.Errorf("unexpected ok: %v @ %v/%v", s, i, j)
+			scc.Bootstrap = []string{}
+			if s, ok := scc.IsValid(); !ok {
+				t.Errorf("unexpected notok: %v @ %v/%v", s, i, j)
 			}
 			scc.Bootstrap = ooo
 


### PR DESCRIPTION
Rel #330 

This is a solution that doesn't alter the behavior or enforce limitations on the `--chain` argument (either `path/to/config/file[.json]` naming or `chain-identity`), but errors and exits if it finds an invalid config file at `path/to/config/file` or `[./]chain-identity`. 

The only edge case this leaves open is if there's a _file_ `chain-identity` in the CWD which is not intended to be used as a configuration file, then it will error. But in this case I think the error will be descriptive enough to allow the user to workaround it.

