### PR TITLE
[ECIP-1029] Include uncles in total difficulty calculation (GHOST)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -762,6 +762,10 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	localTd := self.GetTd(self.currentBlock.Hash())
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 
+	for _, uncle := range block.uncles {
+		externTd = new(big.Int).Add(uncle.Difficulty(), externTd)
+	}
+
 	// If the total difficulty is higher than our known, add it to the canonical chain
 	// Second clause in the if statement reduces the vulnerability to selfish mining.
 	// Please refer to http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -762,8 +762,11 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	localTd := self.GetTd(self.currentBlock.Hash())
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 
-	for _, uncle := range block.Uncles() {
-		externTd = new(big.Int).Add(uncle.Difficulty, externTd)
+	// #GHOST Include uncles in total difficulty calculation
+	if _, _, configured := self.config.GetFeature(block.Number(), "ecip1029"); configured {
+		for _, uncle := range block.Uncles() {
+			externTd = new(big.Int).Add(uncle.Difficulty, externTd)
+		}
 	}
 
 	// If the total difficulty is higher than our known, add it to the canonical chain

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -762,7 +762,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	localTd := self.GetTd(self.currentBlock.Hash())
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 
-	for _, uncle := range block.uncles {
+	for _, uncle := range block.Uncles() {
 		externTd = new(big.Int).Add(uncle.Difficulty(), externTd)
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -763,7 +763,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 
 	for _, uncle := range block.Uncles() {
-		externTd = new(big.Int).Add(uncle.Difficulty(), externTd)
+		externTd = new(big.Int).Add(uncle.Difficulty, externTd)
 	}
 
 	// If the total difficulty is higher than our known, add it to the canonical chain

--- a/core/data_chainconfig.go
+++ b/core/data_chainconfig.go
@@ -178,6 +178,26 @@ var TestConfig = &ChainConfig{
 				},
 			},
 		},
+		{
+			Name: "Monetary Policy",
+			Block: big.NewInt(2500000),
+			Features: []*ForkFeature{
+				{
+					ID: "ecip1017",
+					Options: ChainFeatureConfigOptions{
+						"type": "reward",
+						"era": 3000000,
+					},
+				},
+				{
+					ID: "ecip1029",
+					Options: ChainFeatureConfigOptions{
+						"type": "difficulty",
+						"name": "ghost",
+					},
+				},
+			},
+		},
 	},
 	BadHashes: []*BadHash{
 		{

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -692,9 +692,13 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 		if parent := pm.blockchain.GetBlock(block.ParentHash()); parent != nil {
 			td = new(big.Int).Add(block.Difficulty(), pm.blockchain.GetTd(block.ParentHash()))
 
-			for _, uncle := range block.Uncles() {
-				td = new(big.Int).Add(uncle.Difficulty, td)
+			// #GHOST
+			if _, _, configured := pm.chainConfig.GetFeature(block.Number(), "ecip1029"); configured {
+				for _, uncle := range block.Uncles() {
+					td = new(big.Int).Add(uncle.Difficulty, td)
+				}
 			}
+
 		} else {
 			glog.V(logger.Error).Infof("propagating dangling block #%d [%x]", block.NumberU64(), hash[:4])
 			return

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -692,7 +692,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 		if parent := pm.blockchain.GetBlock(block.ParentHash()); parent != nil {
 			td = new(big.Int).Add(block.Difficulty(), pm.blockchain.GetTd(block.ParentHash()))
 
-			for _, uncle := range block.uncles {
+			for _, uncle := range block.Uncles() {
 				td = new(big.Int).Add(uncle.Difficulty(), td)
 			}
 		} else {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -691,6 +691,10 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 		var td *big.Int
 		if parent := pm.blockchain.GetBlock(block.ParentHash()); parent != nil {
 			td = new(big.Int).Add(block.Difficulty(), pm.blockchain.GetTd(block.ParentHash()))
+
+			for _, uncle := range block.uncles {
+				td = new(big.Int).Add(uncle.Difficulty(), td)
+			}
 		} else {
 			glog.V(logger.Error).Infof("propagating dangling block #%d [%x]", block.NumberU64(), hash[:4])
 			return

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -693,7 +693,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 			td = new(big.Int).Add(block.Difficulty(), pm.blockchain.GetTd(block.ParentHash()))
 
 			for _, uncle := range block.Uncles() {
-				td = new(big.Int).Add(uncle.Difficulty(), td)
+				td = new(big.Int).Add(uncle.Difficulty, td)
 			}
 		} else {
 			glog.V(logger.Error).Infof("propagating dangling block #%d [%x]", block.NumberU64(), hash[:4])

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -30,16 +30,17 @@ import (
 const (
 	eth62 = 62
 	eth63 = 63
+	eth70 = 70
 )
 
 // Official short name of the protocol used during capability negotiation.
 var ProtocolName = "eth"
 
 // Supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{eth63, eth62}
+var ProtocolVersions = []uint{eth70, eth63, eth62}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{17, 8}
+var ProtocolLengths = []uint64{17, 17, 8}
 
 const (
 	NetworkId          = 1


### PR DESCRIPTION
See [ECIP-1029](https://github.com/ethereumproject/ECIPs/blob/ecip-1029/ECIPs/ECIP-1029.md) for more information.

Note that while the GHOST protocol is published a long time ago and has been advertised to be used by Ethereum, due to the sort-of design flaw, it is actually never used by any well-known cryptocurrencies. Thus what I suggest is that we test this PR on a testnet first, make sure it runs stable, before taking measures to merge ECIP-1029 and incorporate this soft-fork into other clients.

The actual change is small while can impact some critical aspect of the consensus. 

TODO:

- [ ] Keep `63` using the old total difficulty meaning.