### PR TITLE
implement 'eth_chainId' JSON-RPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Rolling builds for the master branch may be found at [builds.etcdevteam.com](bui
 
 #### Added
 - JSON-RPC: `debug_traceTransaction` method
+- JSON-RPC: `eth_chainId` method; returns configured Ethereum EIP-155 chain id for signing protected txs
 - P2P: improve peer discovery by allowing "good-will" for peers with unknown HF blocks
 
 ## [3.5.86] - 2017-07-19 - db60074

--- a/eth/api.go
+++ b/eth/api.go
@@ -176,6 +176,15 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	}, nil
 }
 
+// ChainId returns the chain-configured value for EIP-155 chain id, used in signing protected txs.
+// If EIP-155 is not configured it will return 0.
+// Number will be returned as a string in hexadecimal format.
+// 61 - Mainnet $((0x3d))
+// 62 - Morden $((0x3e))
+func (s *PublicEthereumAPI) ChainId() *big.Int {
+	return s.e.chainConfig.GetChainID()
+}
+
 // PublicMinerAPI provides an API to control the miner.
 // It offers only methods that operate on data that pose no security risk when it is publicly accessible.
 type PublicMinerAPI struct {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -340,6 +340,11 @@ web3._extend({
 			call: 'eth_submitTransaction',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'chainId',
+			call: 'eth_chainId',
+			params: 0
 		})
 	],
 	properties:


### PR DESCRIPTION
Rel #335 

I chose to return the number in hexadecimal format because that's consistent with the other `eth_` call returning a *big.Int `eth_gasPrice`. I'm not set on this; it may be better to return as a plain int since there's no need for _big_ness. Another option would be to return as a string, akin to `net_version`, which returns `"1"` and `"2"`. 

In case no chain id is configured, it will return 0.

Finally, it may be useful to also include the fork number at which EIP155 is implemented for the given configuration; Morden -> 1915000, Mainnet -> 3000000, custom/private -> _n_

Eg: 
Current proposed:
```json 
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "0x3d"
}
```

or possibly with fork number:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
      "chainId": "0x3d",
      "blockNumber": "0x2dc6c0"
    }
}
```

Thoughts welcome.