### PR TITLE
miner: fix panic in worker tx commit

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -697,7 +697,7 @@ func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, g
 	if logger.MlogEnabled() {
 		defer func() {
 			mlogMiner.Send(mlogMinerCommitTx.SetDetailValues(
-				env.Block.Number(),
+				env.header.Number,
 				tx.Hash().Hex(),
 				err,
 			))


### PR DESCRIPTION
Caused by wrong reference for logging mined block number; should have used `env.header` instead of `env.Block.header`.

Rel #357 