### PR TITLE
cmd/geth: allow --exec flag as global or command flag

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -37,6 +37,9 @@ The Geth console is an interactive shell for the JavaScript runtime environment
 which exposes a node admin interface as well as the Ðapp JavaScript API.
 See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 `,
+		Flags: []cli.Flag{
+			ExecFlag,
+		},
 	}
 	attachCommand = cli.Command{
 		Action: remoteConsole,
@@ -48,6 +51,9 @@ which exposes a node admin interface as well as the Ðapp JavaScript API.
 See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console.
 This command allows to open a console on a running geth node.
 	`,
+		Flags: []cli.Flag{
+			ExecFlag,
+		},
 	}
 	javascriptCommand = cli.Command{
 		Action: ephemeralConsole,
@@ -86,10 +92,19 @@ func localConsole(ctx *cli.Context) error {
 	defer console.Stop(false)
 
 	// If only a short execution was requested, evaluate and return
+	//
+	// --exec as command sub-flag
+	if script := ctx.String(ExecFlag.Name); script != "" {
+		console.Evaluate(script)
+		return nil
+	}
+
+	// --exec as global flag
 	if script := ctx.GlobalString(ExecFlag.Name); script != "" {
 		console.Evaluate(script)
 		return nil
 	}
+
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
@@ -125,6 +140,14 @@ func remoteConsole(ctx *cli.Context) error {
 	defer console.Stop(false)
 
 	// If only a short execution was requested, evaluate and return
+	//
+	// --exec as command sub-flag
+	if script := ctx.String(ExecFlag.Name); script != "" {
+		console.Evaluate(script)
+		return nil
+	}
+
+	// --exec as global flag
 	if script := ctx.GlobalString(ExecFlag.Name); script != "" {
 		console.Evaluate(script)
 		return nil

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -208,6 +208,17 @@ for the 'discover' component.
 			}
 		}
 
+		// Check for --exec set without console OR attach
+		if ctx.IsSet(ExecFlag.Name) {
+			// If no command is used, OR command is not one of the valid commands attach/console
+			if cmdName := ctx.Args().First(); cmdName == "" || (cmdName != "console" && cmdName != "attach") {
+				log.Printf("Error: --%v flag requires use of 'attach' OR 'console' command, command was: '%v'", ExecFlag.Name, cmdName)
+				cli.ShowCommandHelp(ctx, consoleCommand.Name)
+				cli.ShowCommandHelp(ctx, attachCommand.Name)
+				os.Exit(1)
+			}
+		}
+
 		runtime.GOMAXPROCS(runtime.NumCPU())
 
 		glog.CopyStandardLogTo("INFO")


### PR DESCRIPTION
Current use:

```shell
$ geth --exec 'console.log("hello");' console
```

Proposed changes allow alternate use:

```shell
$ geth console --exec 'console.log("hello");'
```

This applies for both commands `console` and `attach`.

In case of invalid use, show usage as below and exit `1`.

```shell
# Use WITHOUT required command attach or console
$ geth --exec 'console.log("hello");'
2017/10/09 09:24:45 Error: --exec flag requires use of 'attach' OR 'console' command, command was: ''
console [command options] [arguments...]

The Geth console is an interactive shell for the JavaScript runtime environment
which exposes a node admin interface as well as the Ðapp JavaScript API.
See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console


OPTIONS:
	--exec value	Execute JavaScript statement (only in combination with console/attach)

attach [command options] [arguments...]

The Geth console is an interactive shell for the JavaScript runtime environment
which exposes a node admin interface as well as the Ðapp JavaScript API.
See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console.
This command allows to open a console on a running geth node.


OPTIONS:
	--exec value	Execute JavaScript statement (only in combination with console/attach)

```

Rel #359