### PR TITLE
implement debug logging/verbosity api methods

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -48,7 +48,6 @@ import (
 	"github.com/ethereumproject/go-ethereum/rlp"
 	"github.com/ethereumproject/go-ethereum/rpc"
 	ethMetrics "github.com/ethereumproject/go-ethereum/metrics"
-	"strconv"
 )
 
 const defaultGas = uint64(90000)
@@ -1754,15 +1753,11 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 func (api *PublicDebugAPI) Verbosity(n uint64) (int, error) {
 	nint := int(n)
 	if nint == 0 {
-		s := glog.GetVerbosity().String()
-		i, e := strconv.Atoi(s)
-		return i, e
+		return int(*glog.GetVerbosity()), nil
 	}
 	if nint <= logger.Detail || nint == logger.Ridiculousness {
 		glog.SetV(nint)
-		s := glog.GetVerbosity().String()
-		i, e := strconv.Atoi(s)
-		return i, e
+		return int(*glog.GetVerbosity()), nil
 	}
 	return -1, errors.New("invalid logging level")
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/rlp"
 	"github.com/ethereumproject/go-ethereum/rpc"
 	ethMetrics "github.com/ethereumproject/go-ethereum/metrics"
+	"strconv"
 )
 
 const defaultGas = uint64(90000)
@@ -1746,13 +1747,15 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 
 // Verbosity implements api method debug_verbosity, enabling setting
 // global logging verbosity on the fly.
-func (api *PublicDebugAPI) Verbosity(n uint64) (string, error) {
+func (api *PublicDebugAPI) Verbosity(n uint64) (int, error) {
 	nint := int(n)
 	if nint <= logger.Detail || nint == logger.Ridiculousness {
 		glog.SetV(nint)
-		return glog.GetVerbosity().String(), nil
+		s := glog.GetVerbosity().String()
+		i, e := strconv.Atoi(s)
+		return i, e
 	}
-	return "", errors.New("invalid logging level")
+	return -1, errors.New("invalid logging level")
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/eth/api.go
+++ b/eth/api.go
@@ -1744,6 +1744,17 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 	return out, nil
 }
 
+// Verbosity implements api method debug_verbosity, enabling setting
+// global logging verbosity on the fly.
+func (api *PublicDebugAPI) Verbosity(n uint64) (string, error) {
+	nint := int(n)
+	if nint <= logger.Detail || nint == logger.Ridiculousness {
+		glog.SetV(nint)
+		return glog.GetVerbosity().String(), nil
+	}
+	return "", errors.New("invalid logging level")
+}
+
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as the amount of
 // gas used and the return value

--- a/eth/api.go
+++ b/eth/api.go
@@ -1747,8 +1747,16 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 
 // Verbosity implements api method debug_verbosity, enabling setting
 // global logging verbosity on the fly.
+// Note that it will NOT allow setting verbosity '0', which is off.
+// In place of ability to receive 0, as arg, debug.verbosity() -> debug.verbosity(0) -> glog.GetVerbosity().
+// Shorthand/convenience method.
 func (api *PublicDebugAPI) Verbosity(n uint64) (int, error) {
 	nint := int(n)
+	if nint == 0 {
+		s := glog.GetVerbosity().String()
+		i, e := strconv.Atoi(s)
+		return i, e
+	}
 	if nint <= logger.Detail || nint == logger.Ridiculousness {
 		glog.SetV(nint)
 		s := glog.GetVerbosity().String()

--- a/eth/api.go
+++ b/eth/api.go
@@ -1758,6 +1758,16 @@ func (api *PublicDebugAPI) Verbosity(n uint64) (int, error) {
 	return -1, errors.New("invalid logging level")
 }
 
+// Vmodule implements api method debug_vmodule, enabling setting
+// glog per-module verbosity settings on the fly.
+func (api *PublicDebugAPI) Vmodule(s string) (string, error) {
+	if s == "" {
+		return glog.GetVModule().String(), nil
+	}
+	err := glog.GetVModule().Set(s)
+	return glog.GetVModule().String(), err
+}
+
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as the amount of
 // gas used and the return value

--- a/eth/api.go
+++ b/eth/api.go
@@ -1747,9 +1747,10 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 
 // Verbosity implements api method debug_verbosity, enabling setting
 // global logging verbosity on the fly.
-// Note that it will NOT allow setting verbosity '0', which is off.
-// In place of ability to receive 0, as arg, debug.verbosity() -> debug.verbosity(0) -> glog.GetVerbosity().
-// Shorthand/convenience method.
+// Note that it will NOT allow setting verbosity '0', which is effectively 'off'.
+// In place of ability to receive 0 as a functional parameter, debug.verbosity() -> debug.verbosity(0) -> glog.GetVerbosity().
+// creates a shorthand/convenience method as a "getter" function returning the current value
+// of the verbosity setting.
 func (api *PublicDebugAPI) Verbosity(n uint64) (int, error) {
 	nint := int(n)
 	if nint == 0 {

--- a/internal/jsre/ethereum_js.go
+++ b/internal/jsre/ethereum_js.go
@@ -3761,13 +3761,13 @@ var inputOptionalBoolFormatter = function (options) {
 };
 
 /**
- * Allows optional boolean value as input. If null input, returns false.
+ * Allows optional number value as input. If null or empty input, returns 0.
  *
- * @method inputVariadicNumberFormatter
+ * @method inputOptionalNumberFormatter
  * @param {bool} optional number val, either of form [number] or number
- * @returns number or []
+ * @returns number
 */
-var inputVariadicNumberFormatter = function (numbers) {
+var inputOptionalNumberFormatter = function (numbers) {
     if (typeof numbers === 'number') {
         return numbers;
     }
@@ -3979,7 +3979,7 @@ module.exports = {
     inputAddressFormatter: inputAddressFormatter,
     inputOptionalBoolFormatter: inputOptionalBoolFormatter,
     inputOptionalStringFormatter: inputOptionalStringFormatter,
-    inputVariadicNumberFormatter: inputVariadicNumberFormatter,
+    inputOptionalNumberFormatter: inputOptionalNumberFormatter,
     inputPostFormatter: inputPostFormatter,
     outputBigNumberFormatter: outputBigNumberFormatter,
     outputTransactionFormatter: outputTransactionFormatter,

--- a/internal/jsre/ethereum_js.go
+++ b/internal/jsre/ethereum_js.go
@@ -3761,6 +3761,40 @@ var inputOptionalBoolFormatter = function (options) {
 };
 
 /**
+ * Allows optional boolean value as input. If null input, returns false.
+ *
+ * @method inputVariadicNumberFormatter
+ * @param {bool} optional number val, either of form [number] or number
+ * @returns number or []
+*/
+var inputVariadicNumberFormatter = function (numbers) {
+    if (typeof numbers === 'number') {
+        return numbers;
+    }
+    if (typeof numbers === 'object') {
+		return numbers[0];
+	}
+    return 0;
+};
+
+/**
+ * Allows optional string value as input. If null input, returns "".
+ *
+ * @method inputOptionalStringFormatter
+ * @param {string} optional string val, either of form [string] or string
+ * @returns string
+*/
+var inputOptionalStringFormatter = function (optionalString) {
+    if (typeof optionalString === 'string') {
+		return optionalString;
+	}
+	if (typeof optionalString === 'object') {
+		return optionalString[0];
+	}
+	return "";
+};
+
+/**
  * Formats the output of a transaction to its proper values
  *
  * @method outputTransactionFormatter
@@ -3944,6 +3978,8 @@ module.exports = {
     inputTransactionFormatter: inputTransactionFormatter,
     inputAddressFormatter: inputAddressFormatter,
     inputOptionalBoolFormatter: inputOptionalBoolFormatter,
+    inputOptionalStringFormatter: inputOptionalStringFormatter,
+    inputVariadicNumberFormatter: inputVariadicNumberFormatter,
     inputPostFormatter: inputPostFormatter,
     outputBigNumberFormatter: outputBigNumberFormatter,
     outputTransactionFormatter: outputTransactionFormatter,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -215,7 +215,7 @@ web3._extend({
 			name: 'verbosity',
 			call: 'debug_verbosity',
 			params: 1,
-            inputFormatter: [web3._extend.formatters.inputVariadicNumberFormatter]
+            inputFormatter: [web3._extend.formatters.inputOptionalNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'vmodule',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -215,13 +215,13 @@ web3._extend({
 			name: 'verbosity',
 			call: 'debug_verbosity',
 			params: 1,
-            inputFormatter: [web3._extend.formatters.inputOptionalNumberFormatter]
+			inputFormatter: [web3._extend.formatters.inputOptionalNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'vmodule',
 			call: 'debug_vmodule',
 			params: 1,
-            inputFormatter: [web3._extend.formatters.inputOptionalStringFormatter]
+			inputFormatter: [web3._extend.formatters.inputOptionalStringFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'backtraceAt',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -214,12 +214,14 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'verbosity',
 			call: 'debug_verbosity',
-			params: 1
+			params: 1,
+            inputFormatter: [web3._extend.formatters.inputVariadicNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'vmodule',
 			call: 'debug_vmodule',
-			params: 1
+			params: 1,
+            inputFormatter: [web3._extend.formatters.inputOptionalStringFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'backtraceAt',


### PR DESCRIPTION
Methods currently exist in web3ext.js, but were unimplemented in API. 

- `debug.verbosity(n)`, where `n` is a uint corresponding to established log levels `1...6,100` (`Error...Detail, Ridiculousness`).
Returns int, eg. `5`, upon successful setting, and error `invalid verbosity value` on fail. Using `debug.verbosity()` (where `n` is nil) caused method to acts a getter function, and returns current value. See `--verbosity` flag for usage context.
```
> debug.verbosity();
3
> debug.verbosity(4);
4
> debug.verbosity(1);
1
```

- `debug.vmodule(s)`, where `s` is a comma-separated `k=v` string, eg. `eth*=3,miner=4,core/blockchain=5`. Returns regex-compiled string matching set input. See `--vmodule` flag for usage context. Like above, an empty parameter (`s = 0`) causes the method to act as a getter.
```
> debug.vmodule();
".*/eth\\*/[^/]+\\.go$=1,.*/p2p/[^/]+\\.go$=6,.*/core/[^/]+\\.go$=4"
> debug.vmodule("miner=6");
".*/miner/[^/]+\\.go$=6"
> debug.vmodule("eth=6");
".*/eth/[^/]+\\.go$=6"
```

Rel #364