### PR TITLE
Fix panic nil pointer miner mlog

### DIFF
--- a/miner/mlog.go
+++ b/miner/mlog.go
@@ -56,7 +56,7 @@ If $COMMIT_UNCLE is non-nil, uncle is not committed.`,
 	Verb: "COMMIT",
 	Subject: "UNCLE",
 	Details: []logger.MLogDetailT{
-		{"COMMIT", "BLOCK_NUMBER", "BIGINT"},
+		{"UNCLE", "BLOCK_NUMBER", "BIGINT"},
 		{"UNCLE", "HASH", "STRING"},
 		{"COMMIT", "ERROR", "STRING_OR_NULL"},
 	},

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -585,7 +585,7 @@ func (self *worker) commitUncle(work *Work, uncle *types.Header) error {
 	if logger.MlogEnabled() {
 		defer func() {
 			mlogMiner.Send(mlogMinerCommitUncle.SetDetailValues(
-				work.Block.Number(),
+				uncle.Number,
 				hash.Hex(),
 				e,
 			))


### PR DESCRIPTION
Will update https://github.com/ethereumproject/go-ethereum/wiki/mlog-API#lines-reference with `MINER.WORK.BLOCK_NUMBER` -> `MINER.UNCLE.BLOCK_NUMBER` signature as well.