### PR TITLE
[WIP - experimental] compile JSON config to Go during CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq bats; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bats; fi
+# Get compiler for JSON resources.
+- go get github.com/omeid/go-resources/cmd/resources
 
 script:
 # Install Janus
@@ -24,6 +26,8 @@ script:
 
 - go version
 - go env
+# Compile JSON chain config resources to Go.
+- resources -declare -var=DEFAULTS -package=assets -output=core/assets/assets.go core/config/*.json
 # Run go tests.
 - go test ./...
 # Build for integration tests.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,11 @@ install:
   - go version
   - go env
   - go get golang.org/x/sys/windows
+  # Get compiler for JSON resources.
+  - go get github.com/omeid/go-resources/cmd/resources
 build_script:
+  # Compile JSON chain config resources to Go.
+  - resources -declare -var=DEFAULTS -package=assets -output=core/assets/assets.go core/config/*.json
   - go test ./...
   - go build -ldflags "-X main.Version=%VERSION%" ./cmd/geth
   - 7z a geth-classic-win64-%VERSION%.zip geth.exe


### PR DESCRIPTION
Would enable removing `/core/assets/assets.go`. 

This is an experiment to test that https://github.com/omeid/go-resources/issues/12 has resolved an issue with resource compilation on Windows.

If we do indeed choose to remove compiled configuration assets (`assets.go`) from source, then we'd need to address how to add that step to building from source. We can either
- include a step in the instructions `resources -declare -var=DEFAULTS -package=assets -output=core/assets/assets.go core/config/*.json` to compile the resources
- use a make file (or mage file)

Rel #347 
Rel #351 