### PR TITLE
feature: reset command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -102,6 +102,16 @@ Use "ethereum dump 0" to dump the genesis block.
 		Show the status of the current configuration.
 		`,
 	}
+	resetCommand = cli.Command{
+		Action: resetChaindata,
+		Name: "reset",
+		Usage: "Reset the chain database",
+		Description: `
+		Reset does a hard reset of the entire chain database.
+		This is a drastic and irreversible command, and should be used with caution.
+		The command will require user confirmation before any action is taken.
+		`,
+	}
 )
 
 func importChain(ctx *cli.Context) error {

--- a/cmd/geth/cmd.bats
+++ b/cmd/geth/cmd.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+: ${GETH_CMD:=$GOPATH/bin/geth}
+
+setup() {
+	DATA_DIR=`mktemp -d`
+}
+
+teardown() {
+	rm -fr $DATA_DIR
+}
+
+@test "reset command" {
+    cp -a $BATS_TEST_DIRNAME/../../cmd/geth/testdata/testdatadir/. $DATA_DIR/
+
+    # Ensure chaindata dir exists before proof of removal.
+    [ -d $DATA_DIR/mainnet/chaindata ]
+
+    # Test with negative user response: SHOULD NOT remove chaindata/
+    run $GETH_CMD --data-dir $DATA_DIR reset <<< $'no'
+    [ "$status" -eq 0 ]
+    [ -d $DATA_DIR/mainnet/chaindata ]
+
+    # Test with affirmative user response: SHOULD remove chaindata/
+    run $GETH_CMD --data-dir $DATA_DIR reset <<< $'y'
+    [ "$status" -eq 0 ]
+    ! [ -d $DATA_DIR/mainnet/chaindata ]
+}

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -1007,11 +1007,13 @@ func makeMLogDocumentation(ctx *cli.Context) error {
 // then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
 // confirmations. If the input is not recognized, it will ask again. The function does not return
 // until it gets a valid response from the user.
+//
+// Use 'error' verbosity for logging since this is user-critical and required feedback.
 func askForConfirmation(s string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s [y/n]: ", s)
+		glog.V(logger.Error).Infof("%s [y/n]: ", s)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {
@@ -1025,7 +1027,9 @@ func askForConfirmation(s string) bool {
 		} else if response == "n" || response == "no" {
 			return false
 		} else {
-			fmt.Println("* INVALID RESPONSE: Please respond with [y|yes] or [n|no], or use CTRL-C to abort.")
+			glog.V(logger.Error).Infoln(glog.Separator("*"))
+			glog.V(logger.Error).Infoln("* INVALID RESPONSE: Please respond with [y|yes] or [n|no], or use CTRL-C to abort.")
+			glog.V(logger.Error).Infoln(glog.Separator("*"))
 		}
 	}
 }
@@ -1035,15 +1039,15 @@ func askForConfirmation(s string) bool {
 func resetChaindata(ctx *cli.Context) error {
 	dir := MustMakeChainDataDir(ctx)
 	dir = filepath.Join(dir, "chaindata")
-	prompt := fmt.Sprintf("\nThis will remove the directory='%s' and all of it's contents.\n** Are you sure you want to remove ALL chain data?", dir)
+	prompt := fmt.Sprintf("\n\nThis will remove the directory='%s' and all of it's contents.\n** Are you sure you want to remove ALL chain data?", dir)
 	c := askForConfirmation(prompt)
 	if c {
 		if err := os.RemoveAll(dir); err != nil {
 			return err
 		}
-		fmt.Printf("Successfully removed chaindata directory: '%s'\n", dir)
+		glog.V(logger.Error).Infof("Successfully removed chaindata directory: '%s'\n", dir)
 	} else {
-		fmt.Println("Leaving chaindata untouched. As you were.")
+		glog.V(logger.Error).Infoln("Leaving chaindata untouched. As you were.")
 	}
 	return nil
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -54,6 +54,7 @@ func makeCLIApp() (app *cli.App) {
 		removedbCommand,
 		dumpCommand,
 		rollbackCommand,
+		resetCommand,
 		monitorCommand,
 		accountCommand,
 		walletCommand,


### PR DESCRIPTION
`rm -rf` chaindata. This is a nuclear (drastic) command.

Basic use:
```
$ geth reset
```

```
$ geth --data-dir="./somewhere" --chain="morden" reset
```


Example:
```shell
# Help/usage information
~/Library/EthereumClassic  ⟠ geth reset --help
reset [arguments...]

		Reset does a hard reset of the entire chain database.
		This is a drastic and irreversible command, and should be used with caution.
		The command will require user confirmation before any action is taken.



# User confirmation required...
~/Library/EthereumClassic  ⟠ geth --chain mainnet-corrupted15 reset

This will remove the directory='/Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata' and all of it's contents.
** Are you sure you want to remove ALL chain data? [y/n]: asd
* INVALID RESPONSE: Please respond with [y|yes] or [n|no], or use CTRL-C to abort.

This will remove the directory='/Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata' and all of it's contents.
** Are you sure you want to remove ALL chain data? [y/n]: ^C
~/Library/EthereumClassic  ⟠ geth --chain mainnet-corrupted15 reset

This will remove the directory='/Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata' and all of it's contents.
** Are you sure you want to remove ALL chain data? [y/n]: n
Leaving chaindata untouched. As you were.
~/Library/EthereumClassic  ⟠ geth --chain mainnet-corrupted15 reset

This will remove the directory='/Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata' and all of it's contents.
** Are you sure you want to remove ALL chain data? [y/n]: y
Successfully removed chaindata directory: '/Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata'

# Restarting geth automatically initializes new 'chaindata' dir and begins to work.
~/Library/EthereumClassic  ⟠ geth --chain mainnet-corrupted15
I1025 09:18:34.946644 cmd/geth/flag.go:808] Using custom chain configuration: mainnet-corrupted15
I1025 09:18:34.946797 cmd/geth/flag.go:811] --------------------------------------------------------------------------------------------------------------
I1025 09:18:34.946804 cmd/geth/flag.go:813] Starting Geth Classic source.v4.0.0+151-083649c.feat-reset-command.17-10-25-09-16-45
I1025 09:18:34.946811 cmd/geth/flag.go:814] Geth is configured to use ETC blockchain: Ethereum Classic Mainnet
I1025 09:18:34.946826 cmd/geth/flag.go:815] Using chain database at: /Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata
I1025 09:18:34.946833 cmd/geth/flag.go:817] 5 blockchain upgrades associated with this configuration:
I1025 09:18:34.946842 cmd/geth/flag.go:820]  1150000 Homestead
I1025 09:18:34.946871 cmd/geth/flag.go:820]  1920000 The DAO Hard Fork
I1025 09:18:34.946882 cmd/geth/flag.go:822]          with block 0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f
I1025 09:18:34.946889 cmd/geth/flag.go:820]  2500000 GasReprice
I1025 09:18:34.946897 cmd/geth/flag.go:820]  3000000 Diehard
I1025 09:18:34.946907 cmd/geth/flag.go:820]  5000000 Gotham
I1025 09:18:34.947022 cmd/geth/flag.go:833] State starting nonce: 0
I1025 09:18:34.947082 cmd/geth/flag.go:836] --------------------------------------------------------------------------------------------------------------
I1025 09:18:34.947318 cmd/geth/flag.go:416] WARNING: No etherbase set and no accounts found as default
I1025 09:18:34.948300 cmd/geth/flag.go:517] Machine logs file: /Users/ia/Library/EthereumClassic/mainnet-corrupted15/mlogs/geth.mh.ia.mlog.20171025-091834.22318
I1025 09:18:34.948407 ethdb/database.go:63] Allotted 128MB cache and 1024 file handles to /Users/ia/Library/EthereumClassic/mainnet-corrupted15/chaindata
I1025 09:18:34.951203 ethdb/database.go:63] Allotted 16MB cache and 16 file handles to /Users/ia/Library/EthereumClassic/mainnet-corrupted15/dapp
I1025 09:18:34.957197 eth/backend.go:155] Protocol Versions: [63 62], Network Id: 1, Chain Id: 61
I1025 09:18:35.646405 eth/backend.go:183] Blockchain DB Version: 3
I1025 09:18:35.646522 eth/backend.go:236] Successfully established mainnet genesis block: 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
I1025 09:18:35.647459 core/blockchain.go:444] Last header: #0 [d4e56740…] TD=17179869184
I1025 09:18:35.647507 core/blockchain.go:445] Last block: #0 [d4e56740…] TD=17179869184
I1025 09:18:35.647522 core/blockchain.go:446] Fast block: #0 [d4e56740…] TD=17179869184
I1025 09:18:35.648063 p2p/server.go:310] Starting Server
I1025 09:18:35.658943 p2p/discover/udp.go:249] Listening, enode://4f04af943280102037fa288966a953b2f12bffaaa1e8f6a7194f4ec7ea0429e48622c0200353e3f18b3b1996ae02fefa2b89fdfcad2d9f436d11e6ab04d95a62@24.171.98.110:30303
I1025 09:18:35.659702 p2p/nat/nat.go:111] Mapped network port udp:30303 -> 30303 (ethereum discovery) using NAT-PMP(192.168.0.1)
I1025 09:18:35.661320 p2p/server.go:553] Listening on [::]:30303
I1025 09:18:35.661670 node/node.go:295] IPC endpoint opened: /Users/ia/Library/EthereumClassic/mainnet-corrupted15/geth.ipc
I1025 09:18:35.679477 p2p/nat/nat.go:111] Mapped network port tcp:30303 -> 30303 (ethereum p2p) using NAT-PMP(192.168.0.1)
^CI1025 09:18:37.872543 cmd/geth/cmd.go:85] Got interrupt, shutting down...
I1025 09:18:37.872797 node/node.go:327] IPC endpoint closed: /Users/ia/Library/EthereumClassic/mainnet-corrupted15/geth.ipc
I1025 09:18:37.872833 core/blockchain.go:820] Chain manager stopped
I1025 09:18:37.872849 eth/handler.go:219] Stopping ethereum protocol handler...
I1025 09:18:37.872875 eth/handler.go:240] Ethereum protocol handler stopped
I1025 09:18:37.872904 core/tx_pool.go:165] Transaction pool stopped
I1025 09:18:37.872953 eth/backend.go:483] Automatic pregeneration of ethash DAG: OFF (ethash dir: /Users/ia/.ethash)

```