### PR TITLE
Set mlog default to 'off'

### DIFF
--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -163,7 +163,7 @@ var (
 	MLogFlag = cli.StringFlag{
 		Name:  "mlog",
 		Usage: "Set machine-readable log format: [plain|kv|json|off]",
-		Value: "kv",
+		Value: "off",
 	}
 	MLogDirFlag = DirectoryFlag{
 		Name:  "mlog-dir",


### PR DESCRIPTION
mlogs are data rich, and if geth is run constantly and often, will require a significant
amount of storage, eg. ~500M for an 8hr sync.

I don't think most users will require mlogs, so let's save them some space.

For users wanting to enable mlogs for log analysis, they can still (of course)
opt-in with '--mlog=[kv|json|plain]'.

Default 'off' setting is also congruent to normal FS logging, which is by default off,
but can be enabled with '--log-dir'.