### PR TITLE
improve CLI usage formatting

### DIFF
--- a/cmd/geth/account.bats
+++ b/cmd/geth/account.bats
@@ -11,8 +11,16 @@ teardown() {
 	rm -fr $DATA_DIR
 }
 
-@test "account list blanko" {
+@test "account <no command> yields help/usage" {
 	run $GETH_CMD --datadir $DATA_DIR account
+	echo "$output"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"USAGE"* ]]
+}
+
+@test "account list yields <blank> (no accounts)" {
+	run $GETH_CMD --datadir $DATA_DIR account list
 	echo "$output"
 
 	[ "$status" -eq 0 ]
@@ -22,7 +30,7 @@ teardown() {
 @test "account list testdata keystore" {
 	cp -R $BATS_TEST_DIRNAME/../../accounts/testdata/keystore $DATA_DIR/mainnet
 
-	run $GETH_CMD --datadir $DATA_DIR account
+	run $GETH_CMD --datadir $DATA_DIR account list
 	echo "$output"
 
 	[ "$status" -eq 0 ]

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -355,7 +355,7 @@ func accountImport(ctx *cli.Context) error {
 	}
 	key, err := crypto.LoadECDSA(keyfile)
 	if err != nil {
-		log.Fatal("keyfile must be given as argument")
+		log.Fatalf("unable to decode keyfile '%s': %v", keyfile, err)
 	}
 	accman := MakeAccountManager(ctx)
 	passphrase := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, MakePasswordList(ctx))

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -46,53 +46,62 @@ var (
 		},
 		Description: `
 
-    get wallet import /path/to/my/presale.wallet
+geth wallet import /path/to/my/presale.wallet
 
-will prompt for your password and imports your ether presale account.
-It can be used non-interactively with the --password option taking a
-passwordfile as argument containing the wallet password in plaintext.
+	Will prompt for your password and imports your ether presale account.
+	It can be used non-interactively with the --password option taking a
+	passwordfile as argument containing the wallet password in plaintext.
 
-`}
+	`}
 	accountCommand = cli.Command{
-		Action: accountList,
+		Action: accountMan,
 		Name:   "account",
 		Usage:  "Manage accounts",
 		Description: `
 
-Manage accounts lets you create new accounts, list all existing accounts,
-import a private key into a new account.
+	Manage accounts lets you create new accounts, list all existing accounts,
+	import a private key into a new account.
 
-'            help' shows a list of subcommands or help for one subcommand.
+	'$ geth account <command> --help' shows help for any subcommand.
 
-It supports interactive mode, when you are prompted for password as well as
-non-interactive mode where passwords are supplied via a given password file.
-Non-interactive mode is only meant for scripted use on test networks or known
-safe environments.
+	It supports interactive mode, when you are prompted for password as well as
+	non-interactive mode where passwords are supplied via a given password file.
+	Non-interactive mode is only meant for scripted use on test networks or known
+	safe environments.
 
-Make sure you remember the password you gave when creating a new account (with
-either new or import). Without it you are not able to unlock your account.
+	Make sure you remember the password you gave when creating a new account (with
+	either new or import). Without it you are not able to unlock your account.
 
-Note that exporting your key in unencrypted format is NOT supported.
+	Note that exporting your key in unencrypted format is NOT supported.
 
-Keys are stored under <DATADIR>/keystore.
-It is safe to transfer the entire directory or the individual keys therein
-between ethereum nodes by simply copying.
-Make sure you backup your keys regularly.
+	Keys are stored under <DATADIR>/<CHAINDIR>/keystore.
+	It is safe to transfer the entire directory or the individual keys therein
+	between ethereum nodes by simply copying.
+	Make sure you backup your keys regularly.
 
-In order to use your account to send transactions, you need to unlock them using
-the '--unlock' option. The argument is a space separated list of addresses or
-indexes. If used non-interactively with a passwordfile, the file should contain
-the respective passwords one per line. If you unlock n accounts and the password
-file contains less than n entries, then the last password is meant to apply to
-all remaining accounts.
+	In order to use your account to send transactions, you need to unlock them using
+	the '--unlock' option. The argument is a space separated list of addresses or
+	indexes. If used non-interactively with a passwordfile, the file should contain
+	the respective passwords one per line. If you unlock n accounts and the password
+	file contains less than n entries, then the last password is meant to apply to
+	all remaining accounts.
 
-And finally. DO NOT FORGET YOUR PASSWORD.
-`,
+	And finally. DO NOT FORGET YOUR PASSWORD.
+		`,
 		Subcommands: []cli.Command{
 			{
 				Action: accountList,
 				Name:   "list",
 				Usage:  "Print account addresses",
+				Description: `
+geth account list
+
+	Lists all accounts found in geth's keystore.
+	Accounts are listed as below:
+
+		Account #0: {7fa65f0395f5ee0bcbae969d711823ab4353beae} /Users/ia/Library/EthereumClassic/mainnet/keystore/UTC--2017-10-31T13-53-59.993482857Z--7fa65f0395f5ee0bcbae969d711823ab4353beae
+		Account #1: {b5c694a4cdbc1820ba4ee8fd6f5ab71a25782534} /Users/ia/Library/EthereumClassic/mainnet/keystore/my_other_key
+				`,
 			},
 			{
 				Action: accountCreate,
@@ -100,21 +109,20 @@ And finally. DO NOT FORGET YOUR PASSWORD.
 				Usage:  "Create a new account",
 				Description: `
 
-    geth account new
+geth account new
 
-Creates a new account. Prints the address.
+	Creates a new account. Prints the address.
+	The account is saved in encrypted format, you are prompted for a passphrase.
 
-The account is saved in encrypted format, you are prompted for a passphrase.
+	You must remember this passphrase to unlock your account in the future.
 
-You must remember this passphrase to unlock your account in the future.
+	For non-interactive use the passphrase can be specified with the --password flag:
 
-For non-interactive use the passphrase can be specified with the --password flag:
+		geth --password <passwordfile> account new
 
-    ethereum --password <passwordfile> account new
-
-Note, this is meant to be used for testing only, it is a bad idea to save your
-password to file or expose in any other way.
-					`,
+	Note, this is meant to be used for testing only, it is a bad idea to save your
+	password to file or expose in any other way.
+				`,
 			},
 			{
 				Action: accountUpdate,
@@ -122,23 +130,21 @@ password to file or expose in any other way.
 				Usage:  "Update an existing account",
 				Description: `
 
-    geth account update <address>
+geth account update <address>
 
-Update an existing account.
+	Update an existing account.
+	The account is saved in the newest version in encrypted format, you are prompted
+	for a passphrase to unlock the account and another to save the updated file.
+	This same command can therefore be used to migrate an account of a deprecated
+	format to the newest format or change the password for an account.
 
-The account is saved in the newest version in encrypted format, you are prompted
-for a passphrase to unlock the account and another to save the updated file.
+	For non-interactive use the passphrase can be specified with the --password flag:
 
-This same command can therefore be used to migrate an account of a deprecated
-format to the newest format or change the password for an account.
+		geth --password <passwordfile> account update <address>
 
-For non-interactive use the passphrase can be specified with the --password flag:
-
-    geth --password <passwordfile> account update <address>
-
-Since only one password can be given, only format update can be performed,
-changing your password is only possible interactively.
-					`,
+	Since only one password can be given, only format update can be performed,
+	changing your password is only possible interactively.
+				`,
 			},
 			{
 				Action: accountImport,
@@ -146,26 +152,25 @@ changing your password is only possible interactively.
 				Usage:  "Import a private key into a new account",
 				Description: `
 
-    geth account import <keyfile>
+geth account import <keyfile>
 
-Imports an unencrypted private key from <keyfile> and creates a new account.
-Prints the address.
+	Imports an unencrypted private key from <keyfile> and creates a new account.
+	Prints the address.
 
-The keyfile is assumed to contain an unencrypted private key in hexadecimal format.
+	The keyfile is assumed to contain an unencrypted private key in hexadecimal format.
+	The account is saved in encrypted format, you are prompted for a passphrase.
 
-The account is saved in encrypted format, you are prompted for a passphrase.
+	You must remember this passphrase to unlock your account in the future.
 
-You must remember this passphrase to unlock your account in the future.
+	For non-interactive use the passphrase can be specified with the -password flag:
 
-For non-interactive use the passphrase can be specified with the -password flag:
+		geth --password <passwordfile> account import <keyfile>
 
-    geth --password <passwordfile> account import <keyfile>
-
-Note:
-As you can directly copy your encrypted accounts to another ethereum instance,
-this import mechanism is not needed when you transfer an account between
-nodes.
-					`,
+	Note:
+	As you can directly copy your encrypted accounts to another ethereum instance,
+	this import mechanism is not needed when you transfer an account between
+	nodes.
+				`,
 			},
 			{
 				Action: accountIndex,
@@ -173,17 +178,17 @@ nodes.
 				Usage:  "Build persistent account index",
 				Description: `
 
-    geth --index-accounts account index
+geth --index-accounts account index
 
-Create keystore directory index cache database (keystore/accounts.db). Relevant for use with large amounts of key files (>10,000).
+	Create keystore directory index cache database (keystore/accounts.db),
+	which is relevant for use with large amounts of key files (>10,000).
 
-While idempotent, this command is only designed to segregate work and setup time for initial index creation.
+	While idempotent, this command is only intended to handle the work of initial index creation.
+	Therefore, it is only useful to run once, when it's your first time using '--index-accounts' flag option,
+	and MUST be run in conjunction with that flag.
 
-It is only useful to run once when it's your first time using '--index-accounts' flag option, and MUST be run in conjunction
-with that option.
-
-It indexes all key files from keystore/* (non-recursively).
-					`,
+	It non-recursively indexes all valid key files from keystore/*
+		`,
 			},
 		},
 	}
@@ -204,6 +209,10 @@ func accountIndex(ctx *cli.Context) error {
 		}
 	}
 	return nil
+}
+
+func accountMan(ctx *cli.Context) error {
+	return cli.ShowSubcommandHelp(ctx)
 }
 
 func accountList(ctx *cli.Context) error {

--- a/cmd/geth/accountdb.bats
+++ b/cmd/geth/accountdb.bats
@@ -11,8 +11,16 @@ teardown() {
 	rm -fr $DATA_DIR
 }
 
-@test "account list blanko" {
+@test "account <no command> yields help/usage" {
 	run $GETH_CMD --datadir $DATA_DIR account
+	echo "$output"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"USAGE"* ]]
+}
+
+@test "account list yields <blank> (no accounts)" {
+	run $GETH_CMD --datadir $DATA_DIR account list
 	echo "$output"
 
 	[ "$status" -eq 0 ]
@@ -26,7 +34,7 @@ teardown() {
 	run $GETH_CMD --data-dir $DATA_DIR --index-accounts account index
 	[ "$status" -eq 0 ]
 
-	run $GETH_CMD --datadir $DATA_DIR --index-accounts account
+	run $GETH_CMD --datadir $DATA_DIR --index-accounts account list
 	echo "$output"
 
 	[ "$status" -eq 0 ]

--- a/cmd/geth/apicmd.go
+++ b/cmd/geth/apicmd.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ethereumproject/go-ethereum/node"
 	"github.com/ethereumproject/go-ethereum/rpc"
+	"os"
 )
 
 var (
@@ -35,21 +36,23 @@ var (
 		Name:   "api",
 		Usage:  "Run any API command",
 		Description: `
-The api command allows to run any method defined in any API module.
+	The api command allows you to communicate (via IPC) with a running geth instance
+	and run any RPC API method.
 
-Each parameter should be passed as JSON representation:
-- no quotations for numbers or booleans,
-- strings must be correclty quoted, like '"some value"' (quotes must be
-  included in string passed to application),
-- complex objects could be passed as JSON string.
+	Each parameter should be passed as JSON representation:
+	- no quotations for numbers or booleans,
+	- strings must be correctly quoted, like '"some value"' (quotes must be
+	  included in string passed to application),
+	- complex objects could be passed as JSON string.
 
-Examples:
-$ geth api eth getBlockByNumber 123 true
-$ geth eth getBlockByNumber '"latest"' true
-$ geth --chain morden api eth sendTransaction '{"from": "0x396599f365093186742c17aab158bf515e978bc7", "gas": "0x5208", "gasPrice": "0x02540be400", "to": "0xa02cee0fc1d3fb4dde86b79fe93e4140671fd949"}'
+	Examples:
 
-Output will be in JSON format.
-`,
+		$ geth api eth getBlockByNumber 123 true
+		$ geth eth getBlockByNumber '"latest"' true
+		$ geth --chain morden api eth sendTransaction '{"from": "0x396599f365093186742c17aab158bf515e978bc7", "gas": "0x5208", "gasPrice": "0x02540be400", "to": "0xa02cee0fc1d3fb4dde86b79fe93e4140671fd949"}'
+
+	Output will be written to stderr in JSON format.
+		`,
 	}
 )
 
@@ -131,6 +134,6 @@ func prettyPrint(result interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(jsonBytes))
+	os.Stderr.Write(jsonBytes)
 	return nil
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -46,10 +46,10 @@ var (
 		Name:   "export",
 		Usage:  `Export blockchain into file`,
 		Description: `
-Requires a first argument of the file to write to.
-Optional second and third arguments control the first and
-last block to write. In this mode, the file will be appended
-if already existing.
+	Requires a first argument of the file to write to.
+	Optional second and third arguments control the first and
+	last block to write. In this mode, the file will be appended
+	if already existing.
 		`,
 	}
 	upgradedbCommand = cli.Command{
@@ -69,9 +69,9 @@ if already existing.
 		Name:   "dump",
 		Usage:  `Dump a specific block from storage`,
 		Description: `
-The arguments are interpreted as block numbers or hashes.
-Use "ethereum dump 0" to dump the genesis block.
-`,
+	The arguments are interpreted as block numbers or hashes.
+	Use "$ geth dump 0" to dump the genesis block.
+		`,
 	}
 	dumpChainConfigCommand = cli.Command{
 		Action:  dumpChainConfig,
@@ -79,8 +79,8 @@ Use "ethereum dump 0" to dump the genesis block.
 		Aliases: []string{"dumpchainconfig"},
 		Usage:   "Dump current chain configuration to JSON file [REQUIRED argument: filepath.json]",
 		Description: `
-		The dump external configuration command writes a JSON file containing pertinent configuration data for
-		the configuration of a chain database. It includes genesis block data as well as chain fork settings.
+	The dump external configuration command writes a JSON file containing pertinent configuration data for
+	the configuration of a chain database. It includes genesis block data as well as chain fork settings.
 		`,
 	}
 	rollbackCommand = cli.Command{
@@ -89,9 +89,9 @@ Use "ethereum dump 0" to dump the genesis block.
 		Aliases: []string{"roll-back", "set-head", "sethead"},
 		Usage:   "Set current head for blockchain, purging antecedent blocks",
 		Description: `
-		Rollback set the current head block for block chain already in the database.
-		This is a destructive action, purging any block more recent than the index specified.
-		Syncing will require downloading contemporary block information from the index onwards.
+	Rollback set the current head block for block chain already in the database.
+	This is a destructive action, purging any block more recent than the index specified.
+	Syncing will require downloading contemporary block information from the index onwards.
 		`,
 	}
 	statusCommand = cli.Command{
@@ -99,7 +99,7 @@ Use "ethereum dump 0" to dump the genesis block.
 		Name:   "status",
 		Usage:  "Display the status of the current node",
 		Description: `
-		Show the status of the current configuration.
+	Show the status of the current configuration.
 		`,
 	}
 )

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -701,7 +701,7 @@ func makedag(ctx *cli.Context) error {
 			if err != nil {
 				glog.Fatal("Can't find dir")
 			}
-			fmt.Println("making DAG, this could take awhile...")
+			glog.V(logger.Info).Infoln("making DAG, this could take awhile...")
 			ethash.MakeDAG(blockNum, dir)
 		}
 	default:

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -33,10 +33,10 @@ var (
 		Name:   "console",
 		Usage:  `Geth Console: interactive JavaScript environment`,
 		Description: `
-The Geth console is an interactive shell for the JavaScript runtime environment
-which exposes a node admin interface as well as the Ðapp JavaScript API.
-See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
-`,
+	The Geth console is an interactive shell for the JavaScript runtime environment
+	which exposes a node admin interface as well as the Ðapp JavaScript API.
+	See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
+		`,
 		Flags: []cli.Flag{
 			ExecFlag,
 		},
@@ -46,11 +46,20 @@ See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 		Name:   "attach",
 		Usage:  `Geth Console: interactive JavaScript environment (connect to node)`,
 		Description: `
-The Geth console is an interactive shell for the JavaScript runtime environment
-which exposes a node admin interface as well as the Ðapp JavaScript API.
-See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console.
-This command allows to open a console on a running geth node.
-	`,
+	The Geth console is an interactive shell for the JavaScript runtime environment
+	which exposes a node admin interface as well as the Ðapp JavaScript API.
+	See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console.
+	This command allows to open a console on a running geth node.
+
+	<DATADIR> and <CHAINDIR> flags will be parsed as usual.
+	For example:
+
+		geth --chain=morden attach
+
+	or,
+
+		geth --data-dir=/path/to/gethdata --chain privatenet attach
+		`,
 		Flags: []cli.Flag{
 			ExecFlag,
 		},
@@ -60,9 +69,9 @@ This command allows to open a console on a running geth node.
 		Name:   "js",
 		Usage:  `Executes the given JavaScript files in the Geth JavaScript VM`,
 		Description: `
-The JavaScript VM exposes a node admin interface as well as the Ðapp
-JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
-`,
+	The JavaScript VM exposes a node admin interface as well as the Ðapp
+	JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
+		`,
 	}
 )
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -68,11 +68,11 @@ func makeCLIApp() (app *cli.App) {
 			Aliases: []string{"makedag"},
 			Usage:   "Generate ethash dag (for testing)",
 			Description: `
-The makedag command generates an ethash DAG in /tmp/dag.
+	The makedag command generates an ethash DAG in /tmp/dag.
 
-This command exists to support the system testing project.
-Regular users do not need to execute it.
-`,
+	This command exists to support the system testing project.
+	Regular users do not need to execute it.
+			`,
 		},
 		{
 			Action:  gpuinfo,
@@ -80,8 +80,8 @@ Regular users do not need to execute it.
 			Aliases: []string{"gpuinfo"},
 			Usage:   "GPU info",
 			Description: `
-Prints OpenCL device info for all found GPUs.
-`,
+	Prints OpenCL device info for all found GPUs.
+			`,
 		},
 		{
 			Action:  gpubench,
@@ -89,28 +89,28 @@ Prints OpenCL device info for all found GPUs.
 			Aliases: []string{"gpubench"},
 			Usage:   "Benchmark GPU",
 			Description: `
-Runs quick benchmark on first GPU found.
-`,
+	Runs quick benchmark on first GPU found.
+			`,
 		},
 		{
 			Action: version,
 			Name:   "version",
 			Usage:  "Print ethereum version numbers",
 			Description: `
-The output of this command is supposed to be machine-readable.
-`,
+	The output of this command is supposed to be machine-readable.
+			`,
 		},
 		{
 			Action: makeMLogDocumentation,
 			Name:   "mdoc",
 			Usage:  "Generate mlog documentation",
 			Description: `
-Auto-generates documentation for all available mlog lines.
-Use -md switch to toggle markdown output (eg. for wiki).
-Arguments may be used to specify exclusive candidate components;
-so 'geth mdoc -md discover' will generate markdown documentation only
-for the 'discover' component.
-`,
+	Auto-generates documentation for all available mlog lines.
+	Use -md switch to toggle markdown output (eg. for wiki).
+	Arguments may be used to specify exclusive candidate components;
+	so 'geth mdoc -md discover' will generate markdown documentation only
+	for the 'discover' component.
+			`,
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name: "md",

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -57,10 +57,10 @@ var (
 		Name:   "monitor",
 		Usage:  `Geth Monitor: node metrics monitoring and visualization`,
 		Description: `
-The Geth monitor is a tool to collect and visualize various internal metrics
-gathered by the node, supporting different chart types as well as the capacity
-to display multiple metrics simultaneously.
-`,
+	The Geth monitor is a tool to collect and visualize various internal metrics
+	gathered by the node, supporting different chart types as well as the capacity
+	to display multiple metrics simultaneously.
+		`,
 		Flags: []cli.Flag{
 			monitorCommandAttachFlag,
 			monitorCommandRowsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -29,7 +29,7 @@ var AppHelpTemplate = `NAME:
    {{.App.Name}} - {{.App.Usage}}
 
 USAGE:
-   {{.App.HelpName}} [options]{{if .App.Commands}} command [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{.App.HelpName}} [options]{{if .App.Commands}} <command> [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}
 VERSION:
    {{.App.Version}}{{if .App.Commands}}
 COMMANDS:


### PR DESCRIPTION
standardize help usage text at 1-tab indent... as well as
- write `api` command output to stderr
- fix account command '--help' and usage behavior ⬇️ 

`$ geth account` used to list accounts (which should be the job of `geth account list`) and `geth account --help` used to show entire global app help usage. Now `geth account [|--help]` shows just relevant account usage info