### PR TITLE
fix trailing slashes from --chain=value/

### DIFF
--- a/cmd/geth/chainconfig.bats
+++ b/cmd/geth/chainconfig.bats
@@ -239,18 +239,6 @@ teardown() {
 	[ -d $DATA_DIR/morden/chaindata ]
 }
 
-@test "--chain='morden\' | exit 0" {
-	# windows path separator == \, i guess
-	run $GETH_CMD --data-dir $DATA_DIR --chain='morden\' --exec='eth.getBlock(0).hash' console
-        echo "$output"
-    	[ "$status" -eq 0 ]
-    	[[ "$output" == *"0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303"* ]]
-
-    	# Ensure we're using the --chain named subdirectory under main $DATA_DIR.
-    	[ -d $DATA_DIR/morden ]
-    	[ -d $DATA_DIR/morden/chaindata ]
-}
-
 ## load /testdata
 
 # Test loading customnet chain configuration from testdata/ JSON file.

--- a/cmd/geth/chainconfig.bats
+++ b/cmd/geth/chainconfig.bats
@@ -218,12 +218,37 @@ teardown() {
 
 	# Ensure we're using the --chain named subdirectory under main $DATA_DIR.
 	[ -d $DATA_DIR/morden ]
-	[ -d $DATA_DIR/morden ]
 	[ -d $DATA_DIR/morden/chaindata ]
 	[ -f $DATA_DIR/morden/chaindata/CURRENT ]
 	[ -f $DATA_DIR/morden/chaindata/LOCK ]
 	[ -f $DATA_DIR/morden/chaindata/LOG ]
 	[ -d $DATA_DIR/morden/keystore ]
+}
+
+# prove that trailing slashes in chain=val/ get removed harmlessly
+@test "--chain='morden/' | exit 0" {
+
+    # *nix path separator == /
+    run $GETH_CMD --data-dir $DATA_DIR --chain=morden/ --exec 'eth.getBlock(0).hash' console
+    echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303"* ]]
+
+	# Ensure we're using the --chain named subdirectory under main $DATA_DIR.
+	[ -d $DATA_DIR/morden ]
+	[ -d $DATA_DIR/morden/chaindata ]
+}
+
+@test "--chain='morden\' | exit 0" {
+	# windows path separator == \, i guess
+	run $GETH_CMD --data-dir $DATA_DIR --chain='morden\' --exec='eth.getBlock(0).hash' console
+        echo "$output"
+    	[ "$status" -eq 0 ]
+    	[[ "$output" == *"0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303"* ]]
+
+    	# Ensure we're using the --chain named subdirectory under main $DATA_DIR.
+    	[ -d $DATA_DIR/morden ]
+    	[ -d $DATA_DIR/morden/chaindata ]
 }
 
 ## load /testdata

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -155,6 +155,12 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 		cacheChainIdentity = identity
 	}()
 
+	if chainFlagVal := ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx)); chainFlagVal != "" && strings.HasSuffix(chainFlagVal, "/") || strings.HasSuffix(chainFlagVal, "\\") {
+		suff := string(chainFlagVal[len(chainFlagVal)-1])
+		chainFlagVal = strings.Replace(chainFlagVal, suff, "", 1)
+		ctx.GlobalSet(aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
+	}
+
 	if chainIsMorden(ctx) {
 		identity = core.DefaultConfigMorden.Identity // this makes '--testnet', '--chain=testnet', and '--chain=morden' all use the same /morden subdirectory, if --chain isn't specified
 		return identity

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -155,10 +155,8 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 		cacheChainIdentity = identity
 	}()
 
-	if chainFlagVal := ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx)); chainFlagVal != "" && strings.HasSuffix(chainFlagVal, "/") || strings.HasSuffix(chainFlagVal, "\\") {
-		suff := string(chainFlagVal[len(chainFlagVal)-1])
-		chainFlagVal = strings.Replace(chainFlagVal, suff, "", 1)
-		ctx.GlobalSet(aliasableName(ChainIdentityFlag.Name, ctx), chainFlagVal)
+	if chainFlagVal := ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx)); chainFlagVal != "" {
+		ctx.GlobalSet(aliasableName(ChainIdentityFlag.Name, ctx), filepath.Clean(chainFlagVal))
 	}
 
 	if chainIsMorden(ctx) {

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -160,7 +160,8 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 	}
 
 	if chainIsMorden(ctx) {
-		identity = core.DefaultConfigMorden.Identity // this makes '--testnet', '--chain=testnet', and '--chain=morden' all use the same /morden subdirectory, if --chain isn't specified
+		// This makes '--testnet', '--chain=testnet', and '--chain=morden' all use the same /morden subdirectory, if --chain isn't specified
+		identity = core.DefaultConfigMorden.Identity
 		return identity
 	}
 	// If --chain is in use.
@@ -169,7 +170,7 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 			identity = core.DefaultConfigMainnet.Identity
 			return identity
 		}
-		// Check for unallowed values.
+		// Check for disallowed values.
 		if chainIdentitiesBlacklist[chainFlagVal] {
 			glog.Fatalf(`%v: %v: reserved word
 					reserved words for --chain flag include: 'chaindata', 'dapp', 'keystore', 'nodekey', 'nodes',


### PR DESCRIPTION
solution: remove them, both as *nix (`/`) and windows separators (`\`)

fixes #391