### PR TITLE
avoid recovery deadlock/loop given invalid block in middle of stored blockchain data

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -692,8 +692,8 @@ func (self *BlockChain) LoadLastState(dryrun bool) error {
 }
 
 // PurgeAbove works like SetHead, but instead of rm'ing head <-> bc.currentBlock,
-// it removes all stored blockchain data n -> *anyexistingblockdata*, where
-// scanHeight is how far beyond n should be checked for existing data, ie n+scanHeight recursively
+// it removes all stored blockchain data n -> *anyexistingblockdata*
+// TODO: possibly replace with kv database iterator
 func (bc *BlockChain) PurgeAbove(n uint64) {
 	bc.mu.Lock()
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -528,7 +528,7 @@ func (self *BlockChain) LoadLastState(dryrun bool) error {
 			return self.Reset()
 		}
 		// Remove all block header and canonical data above recoveredHeight
-		self.PurgeAbove(recoveredHeight + 1, 2048)
+		self.PurgeAbove(recoveredHeight + 1)
 		return self.SetHead(recoveredHeight)
 	}
 
@@ -686,20 +686,19 @@ func (self *BlockChain) LoadLastState(dryrun bool) error {
 	glog.V(logger.Info).Infof("Last block: #%d [%x…] TD=%v", self.currentBlock.Number(), self.currentBlock.Hash().Bytes()[:4], blockTd)
 	glog.V(logger.Info).Infof("Fast block: #%d [%x…] TD=%v", self.currentFastBlock.Number(), self.currentFastBlock.Hash().Bytes()[:4], fastTd)
 
-	self.mu.Unlock()
 	return nil
 }
 
 // PurgeAbove works like SetHead, but instead of rm'ing head <-> bc.currentBlock,
 // it removes all stored blockchain data n -> *anyexistingblockdata*, where
 // scanHeight is how far beyond n should be checked for existing data, ie n+scanHeight recursively
-func (bc *BlockChain) PurgeAbove(n uint64, scanHeight uint64) {
+func (bc *BlockChain) PurgeAbove(n uint64) {
 	bc.mu.Lock()
 
 	delFn := func(hash common.Hash) {
 		DeleteBody(bc.chainDb, hash)
 	}
-	bc.hc.PurgeAbove(n, scanHeight, delFn)
+	bc.hc.PurgeAbove(n, delFn)
 	bc.mu.Unlock()
 }
 

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -413,6 +413,10 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 // each header is deleted.
 type DeleteCallback func(common.Hash)
 
+// PurgeAbove remove blockchain data above given head 'n'.
+// Similar to hc.SetHead, but uses hardcoded 2048 scan range to check
+// for existing blockchain above last found existing head.
+// TODO: possibly replace with kv database iterator
 func (hc *HeaderChain) PurgeAbove(n uint64, delFn DeleteCallback) {
 
 	glog.V(logger.Warn).Infof("Purging block data above #%d", n)

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -427,7 +427,9 @@ func (hc *HeaderChain) PurgeAbove(n uint64, delFn DeleteCallback) {
 	}()
 
 	lastFoundHeaderN := n
-	for head := hc.GetHeaderByNumber(n); head != nil || n < lastFoundHeaderN + 2048; n++ {
+	var head *types.Header = nil
+	for ; head != nil || n < lastFoundHeaderN+2048; n++ {
+		head = hc.GetHeaderByNumber(n)
 		if head != nil {
 			lastFoundHeaderN = n
 

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -427,7 +427,7 @@ func (hc *HeaderChain) PurgeAbove(n uint64, delFn DeleteCallback) {
 	}()
 
 	lastFoundHeaderN := n
-	for head := hc.GetHeaderByNumber(n); head != nil || lastFoundHeaderN > n - 2048; n++ {
+	for head := hc.GetHeaderByNumber(n); head != nil || n < lastFoundHeaderN + 2048; n++ {
 		if head != nil {
 			lastFoundHeaderN = n
 


### PR DESCRIPTION
One of the checks that gets run as a part of blockchain stability/recoverability is to see if there's any block data _beyond_ the current apparent stored `head` block. And `blockchain.Recover()` begins at `1` and moves forward incrementally until it finds an invalid block. If it finds an invalid block at `100`, it will recover to block `99` and set the new head there. However, since `blockchain.SetHead(99)` only purges blocks _between_ the new head and the old head (eg. `99` and `100`), there will still exist block data for `101`. Because of this, `blockchain.LoadLastState` will find block `101` (again) and restart the recovery process.

While an invalid block in the _middle_ of the blockchain is very rare and probably only exists for data that's been corrupted on purpose (normally it will be at the head), we have to assume the worse: that the block was somehow forged or otherwise invalid and that all data beyond it is untrustable. So we must remove all data beyond the first invalid block. 

This also fixes an issue with the `blockchain.mu` mutex possibly causing a deadlock when attempting to set a recovered head.

I think this bugfix should be included with release `4.1.1`.