### PR TITLE
[WIP] eth: drop ttl scaling after initial sync

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -54,7 +54,7 @@ const (
 
 var (
 	rttMinEstimate   = 2 * time.Second  // Minimum round-trip time to target for download requests
-	rttMaxEstimate   = 20 * time.Second // Maximum rount-trip time to target for download requests
+	rttMaxEstimate   = 20 * time.Second // Maximum round-trip time to target for download requests
 	rttMinConfidence = 0.1              // Worse confidence factor in our estimated RTT value
 	ttlScaling       = 3                // Constant scaling factor for RTT -> TTL conversion
 	ttlLimit         = time.Minute      // Maximum TTL allowance to prevent reaching crazy timeouts
@@ -72,7 +72,7 @@ var (
 	fsHeaderForceVerify    = 24   // Number of headers to verify before and after the pivot to accept it
 	fsPivotInterval        = 512  // Number of headers out of which to randomize the pivot point
 	fsMinFullBlocks        = 1024 // Number of blocks to retrieve fully even in fast sync
-	fsCriticalTrials       = 10   // Number of times to retry in the cricical section before bailing
+	fsCriticalTrials       = 10   // Number of times to retry in the critical section before bailing
 )
 
 var (
@@ -330,6 +330,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 	switch err {
 	case nil:
 		log.Printf("peer %q sync complete", id)
+		ttlScaling = 1 // Modify timeout scaling, shrinking it because now we can be less patient
 		return true
 
 	case errBusy:


### PR DESCRIPTION
### problem

If a "normal" fork appears and our node finds a node with a higher difficulty beyond or to the side of known announced blocks, it will attempt to sync. While a "patient" TTL (timeout for fetch/download) sync timeout of `3` (where `TTL = RTT*3`, eg. `18s * 3 = 54s`) is adequate for initial sync because we expect large amounts of headers/blocks to be transferred (eg 192, 2048), it is overly patient when we've already reached the head and have far fewer blocks to catch up with (eg. less than 30 at most). 

### solution

Once an initial sync with a peer is finished, drop TTL scaling rate to `1`, so `RTT==TTL`. _This is just a proof of concept!_ There is definitely probably a better way to dynamically modify the rate within some bounds so nodes with slower connections don't fall behind.

Also rel #311, w/r/t to better dynamic timeout/qos handling
