### PR TITLE
cmd,core,eth,logger: prettify logging

### DIFF
--- a/cmd/geth/cmd.bats
+++ b/cmd/geth/cmd.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-
 : ${GETH_CMD:=$GOPATH/bin/geth}
 
 setup() {

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -81,7 +81,7 @@ func StartNode(stack *node.Node) {
 		signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
 		defer signal.Stop(sigc)
 		sig := <-sigc
-		glog.Infof("Got %v, shutting down...", sig)
+		glog.V(logger.Error).Warnf("Got %v, shutting down...", sig)
 
 		fails := make(chan error, 1)
 		go func(fs chan error) {

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -885,7 +885,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			var mGasPerSecond = new(big.Int)
 
 			if numBlocksDiff > 0 && numBlocksDiff != current {
-				for i := lastLoggedBlockNumber; i <= current; i++ {
+				for i := lastLoggedBlockNumber+1; i <= current; i++ {
 					b := blockchain.GetBlockByNumber(i)
 					if b != nil {
 						numTxsDiff += b.Transactions().Len()
@@ -927,7 +927,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			if !importMode {
 				blocksprocesseddisplay = fmt.Sprintf("%4d/%4d/%2d blks/txs/mgas sec", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
 			} else {
-				blocksprocesseddisplay = fmt.Sprintf("  + %4d/%4d/%2d blks/txs/mgas", numBlocksDiff, numTxsDiff, mGas.Uint64())
+				blocksprocesseddisplay = fmt.Sprintf("+( blks=%4d txs=%4d mgas=%2d )", numBlocksDiff, numTxsDiff, mGas.Uint64())
 			}
 
 			// Log to ERROR.

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -927,7 +927,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			if !importMode {
 				blocksprocesseddisplay = fmt.Sprintf("%4d/%4d/%2d blks/txs/mgas sec", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
 			} else {
-				blocksprocesseddisplay = fmt.Sprintf("+%4d blks +%4d txs +%8d mgas ", numBlocksDiff, numTxsDiff, mGas.Uint64())
+				blocksprocesseddisplay = fmt.Sprintf("+%4d blks  %4d txs %8d mgas  ", numBlocksDiff, numTxsDiff, mGas.Uint64())
 			}
 
 			// Log to ERROR.

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -864,7 +864,8 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 					currentBlockHex = blockchain.CurrentFastBlock().Hash().Hex()
 				}
 			}
-			if current == height && !(current == 0 && height == 0) {
+			importMode := current >= height && !(current == 0 && height == 0)
+			if importMode {
 				fMode = "Import  " // with spaces to make same length as Discover, FastSync, FullSync
 				fOfHeight = strings.Repeat(" ", 12)
 				fHeightRatio = strings.Repeat(" ", 7)
@@ -922,7 +923,12 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			blockprogress := fmt.Sprintf("#%7d%s", current, fOfHeight)
 			cbhexdisplay := fmt.Sprintf("%s…%s", cbhexstart, cbhexend)
 			peersdisplay := fmt.Sprintf("%2d/%2d peers", lenPeers, maxPeers)
-			blocksprocesseddisplay := fmt.Sprintf("%4d/%4d/%2d blks/txs/mgas sec", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
+			var blocksprocesseddisplay string
+			if !importMode {
+				blocksprocesseddisplay = fmt.Sprintf("%4d/%4d/%2d blks/txs/mgas sec", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
+			} else {
+				blocksprocesseddisplay = fmt.Sprintf("  + %4d/%4d/%2d blks/txs/mgas", numBlocksDiff, numTxsDiff, mGas.Uint64())
+			}
 
 			// Log to ERROR.
 			// This allows maximum user optionality for desired integration with rest of event-based logging.

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -905,6 +905,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			// Don't show initial current / per second val
 			if lastLoggedBlockNumber == 0 {
 				numBlocksDiffPerSecond = 0
+				numBlocksDiff = 0
 			}
 
 			// Divide by interval to yield per-second stats

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -956,9 +956,6 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			peersdisplay := fmt.Sprintf("%2d/%2d peers", lenPeers, maxPeers)
 			var blocksprocesseddisplay string
 			if lsMode != lsModeImport {
-				//I1127 09:44:29.125596  STATUS SYNC Discover #4911173                     24e…31a    0/   0/ 0 blks/txs/mgas sec  0/25 peers
-				//I1127 09:44:14.122299  STATUS SYNC Import   #4911173                     24e…31a +   0 blks     0 txs        0 mgas    1/25 peers
-				//I1127 09:44:29.125596  STATUS SYNC Discover #4911173                     24e…31a ~   0 blks     0 txs  0 mgas    /s    0/25 peers
 				blocksprocesseddisplay = fmt.Sprintf("~%4d blks %4d txs %2d mgas  /sec ", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
 			} else {
 				blocksprocesseddisplay = fmt.Sprintf("+%4d blks %4d txs %8d mgas ", numBlocksDiff, numTxsDiff, mGas.Uint64())

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -927,7 +927,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			if !importMode {
 				blocksprocesseddisplay = fmt.Sprintf("%4d/%4d/%2d blks/txs/mgas sec", numBlocksDiffPerSecond, numTxsDiffPerSecond, mGasPerSecondI)
 			} else {
-				blocksprocesseddisplay = fmt.Sprintf("+( blks=%4d txs=%4d mgas=%2d )", numBlocksDiff, numTxsDiff, mGas.Uint64())
+				blocksprocesseddisplay = fmt.Sprintf("+%4d blks +%4d txs +%8d mgas ", numBlocksDiff, numTxsDiff, mGas.Uint64())
 			}
 
 			// Log to ERROR.

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -900,15 +900,29 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 			var numTxsDiffPerSecond int
 			var mGasPerSecond = new(big.Int)
 
+			// 🁣🁤🁥🁦🁭🁴🁻🁼🂃🂄🂋🂌🂓
+			var dominoes = []string{"🁣", "🁤", "🁥", "🁦", "🁭", "🁴", "🁻", "🁼", "🂃", "🂄", "🂋", "🂌", "🂓"} // len 13
+			var dominoGraph = "\x1b[32m" // set color
 			if numBlocksDiff > 0 && numBlocksDiff != current {
 				for i := lastLoggedBlockNumber+1; i <= current; i++ {
 					b := blockchain.GetBlockByNumber(i)
 					if b != nil {
-						numTxsDiff += b.Transactions().Len()
+						txLen := b.Transactions().Len()
+						// Add to tallies
+						numTxsDiff += txLen
 						mGas = new(big.Int).Add(mGas, b.GasUsed())
+						// Domino effect
+						if lsMode == lsModeImport {
+							if txLen > len(dominoes)-1 {
+								// prevent slice out of bounds
+								txLen = len(dominoes)-1
+							}
+							dominoGraph += dominoes[txLen]
+						}
 					}
 				}
 			}
+			dominoGraph += "\x1b[33m" // reset color
 
 			// Convert to per-second stats
 			// FIXME(?): Some degree of rounding will happen.
@@ -952,7 +966,7 @@ func runStatusSyncLogs(e *eth.Ethereum, interval string, maxPeers int) {
 
 			// Log to ERROR.
 			// This allows maximum user optionality for desired integration with rest of event-based logging.
-			glog.V(logger.Error).Infof("STATUS SYNC %s %s %s %s %s %s", lsModeName[lsMode], blockprogress, fHeightRatio, cbhexdisplay, blocksprocesseddisplay, peersdisplay)
+			glog.V(logger.Error).Infof("STATUS SYNC %s %s %s %s %s %s %s", lsModeName[lsMode], blockprogress, fHeightRatio, cbhexdisplay, blocksprocesseddisplay, peersdisplay, dominoGraph)
 
 		case <-sigc:
 			// Listen for interrupt

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -588,7 +588,7 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 	} else {
 		// Just demonstrative code.
 		if b := logger.SetMlogEnabled(false); b == false && logger.MlogEnabled() == false {
-			glog.V(logger.Warn).Infof("Machine logs: disabled")
+			glog.V(logger.Warn).Warnf("Machine logs: disabled")
 		}
 	}
 

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -158,7 +158,7 @@ var (
 	LogStatusFlag = cli.StringFlag{
 		Name:  "log-status",
 		Usage: `Toggle interval-based STATUS logs: comma-separated list of <pattern>=<interval>`,
-		Value: "sync=60",
+		Value: "sync=15",
 	}
 	MLogFlag = cli.StringFlag{
 		Name:  "mlog",

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -140,6 +140,10 @@ var (
 	}
 
 	// logging and debug settings
+	PrettyFlag = cli.BoolFlag{
+		Name: "pretty",
+		Usage: "Use pretty defaults for logging (verbosity=1,vmodule='cmd/geth/*=3',verbosity-trace-floor=5,log-status='sync=15')",
+	}
 	VerbosityFlag = cli.GenericFlag{
 		Name:  "verbosity",
 		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=core, 5=debug, 6=detail",
@@ -153,7 +157,7 @@ var (
 	VerbosityTraceFloorFlag = cli.IntFlag{
 		Name: "verbosity-trace-floor",
 		Usage: "Floor verbosity level at which to include file traces on log lines.",
-		Value: 5,
+		Value: 0,
 	}
 	LogDirFlag = DirectoryFlag{
 		Name:  "log-dir,logdir",

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -150,6 +150,11 @@ var (
 		Usage: "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=6,p2p=5)",
 		Value: glog.GetVModule(),
 	}
+	VerbosityTraceFloorFlag = cli.IntFlag{
+		Name: "verbosity-trace-floor",
+		Usage: "Floor verbosity level at which to include file traces on log lines.",
+		Value: 5,
+	}
 	LogDirFlag = DirectoryFlag{
 		Name:  "log-dir,logdir",
 		Usage: "Directory in which to write log files.",

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -173,6 +173,7 @@ func makeCLIApp() (app *cli.App) {
 		RPCCORSDomainFlag,
 		VerbosityFlag,
 		VModuleFlag,
+		VerbosityTraceFloorFlag,
 		LogDirFlag,
 		LogStatusFlag,
 		MLogFlag,
@@ -235,6 +236,12 @@ func makeCLIApp() (app *cli.App) {
 			}
 		} else {
 			glog.SetToStderr(true)
+		}
+
+		if ctx.GlobalIsSet(VerbosityTraceFloorFlag.Name) {
+			val := ctx.GlobalInt(VerbosityTraceFloorFlag.Name)
+			log.Println("--verbosity-trace-floor", "val", val)
+			glog.SetVTraceThreshold(val)
 		}
 
 		if s := ctx.String("metrics"); s != "" {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -295,7 +295,7 @@ func geth(ctx *cli.Context) error {
 	n := MakeSystemNode(Version, ctx)
 	ethe := startNode(ctx, n)
 
-	if ctx.GlobalIsSet(LogStatusFlag.Name) {
+	if ctx.GlobalString(LogStatusFlag.Name) != "" {
 		dispatchStatusLogs(ctx, ethe)
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -136,6 +136,7 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "LOGGING AND DEBUGGING",
 		Flags: []cli.Flag{
+			PrettyFlag,
 			VerbosityFlag,
 			VModuleFlag,
 			VerbosityTraceFloorFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -138,6 +138,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			VerbosityFlag,
 			VModuleFlag,
+			VerbosityTraceFloorFlag,
 			LogDirFlag,
 			LogStatusFlag,
 			MLogFlag,

--- a/eth/api.go
+++ b/eth/api.go
@@ -1772,6 +1772,18 @@ func (api *PublicDebugAPI) Vmodule(s string) (string, error) {
 	return glog.GetVModule().String(), err
 }
 
+func (api *PublicDebugAPI) VerbosityTraceFloor(n uint64) (int, error) {
+	nint := int(n)
+	if nint == 0 {
+		return int(*glog.GetVTraceThreshold()), nil
+	}
+	if nint <= logger.Detail || nint == logger.Ridiculousness {
+		glog.SetVTraceThreshold(nint)
+		return int(*glog.GetVTraceThreshold()), nil
+	}
+	return -1, errors.New("invalid logging level")
+}
+
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as the amount of
 // gas used and the return value

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -246,6 +246,13 @@ func (d *Downloader) Progress() (uint64, uint64, uint64, uint64, uint64) {
 	return d.syncStatsChainOrigin, current, d.syncStatsChainHeight, d.syncStatsStateDone, d.syncStatsStateDone + pendingStates
 }
 
+func (d *Downloader) Qos() (rtt time.Duration, ttl time.Duration, conf float64) {
+	rtt = d.requestRTT()
+	ttl = d.requestTTL()
+	conf = float64(d.rttConfidence)/1000000.0
+	return
+}
+
 // Synchronising returns whether the downloader is currently retrieving blocks.
 func (d *Downloader) Synchronising() bool {
 	return atomic.LoadInt32(&d.synchronising) > 0

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"math/big"
 	"strings"
@@ -312,22 +311,22 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 	err := d.synchronise(id, head, td, mode)
 	switch err {
 	case nil:
-		log.Printf("peer %q sync complete", id)
+		glog.V(logger.Core).Infof("Peer %s: sync complete", id)
 		return true
 
 	case errBusy:
-		glog.V(logger.Debug).Info("sync busy")
+		glog.V(logger.Debug).Warnln("sync busy")
 
 	case errTimeout, errBadPeer, errStallingPeer, errEmptyHashSet,
 		errEmptyHeaderSet, errPeersUnavailable, errTooOld,
 		errInvalidAncestor, errInvalidChain:
-		log.Printf("peer %q drop: %s", id, err)
+		glog.V(logger.Core).Warnf("Peer %s: drop: %s", id, err)
 		d.dropPeer(id)
 
 	case errCancelBlockFetch, errCancelHeaderFetch, errCancelBodyFetch, errCancelReceiptFetch, errCancelStateFetch, errCancelHeaderProcessing, errCancelContentProcessing:
 
 	default:
-		log.Printf("peer %q sync: %s", id, err)
+		glog.V(logger.Core).Warnf("Peer %s: sync: %s", id, err)
 	}
 
 	return false

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -691,7 +691,7 @@ func (d *Downloader) findAncestor(p *peer, height uint64) (uint64, error) {
 	// If the head fetch already found an ancestor, return
 	if !common.EmptyHash(hash) {
 		if int64(number) <= floor {
-			glog.V(logger.Warn).Infof("%v: potential rewrite attack: #%d [%x…] <= #%d limit", p, number, hash[:4], floor)
+			glog.V(logger.Warn).Warnf("%v: potential rewrite attack: #%d [%x…] <= #%d limit", p, number, hash[:4], floor)
 			return 0, errInvalidAncestor
 		}
 		glog.V(logger.Debug).Infof("%v: common ancestor: #%d [%x…]", p, number, hash[:4])
@@ -754,7 +754,7 @@ func (d *Downloader) findAncestor(p *peer, height uint64) (uint64, error) {
 	}
 	// Ensure valid ancestry and return
 	if int64(start) <= floor {
-		glog.V(logger.Warn).Infof("%v: potential rewrite attack: #%d [%x…] <= #%d limit", p, start, hash[:4], floor)
+		glog.V(logger.Warn).Warnf("%v: potential rewrite attack: #%d [%x…] <= #%d limit", p, start, hash[:4], floor)
 		return 0, errInvalidAncestor
 	}
 	glog.V(logger.Debug).Infof("%v: common ancestor: #%d [%x…]", p, start, hash[:4])

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -432,7 +432,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if len(headers) > 0 || !filter {
 			err := pm.downloader.DeliverHeaders(p.id, headers)
 			if err != nil {
-				glog.V(logger.Debug).Infoln(err)
+				glog.V(logger.Debug).Infoln("peer", p.id, err)
 			}
 		}
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -261,7 +261,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	// Register the peer locally
 	glog.V(logger.Detail).Infof("%v: adding peer", p)
 	if err := pm.peers.Register(p); err != nil {
-		glog.V(logger.Error).Infof("%v: addition failed: %v", p, err)
+		glog.V(logger.Error).Errorf("%v: addition failed: %v", p, err)
 		return err
 	}
 	defer pm.removePeer(p.id)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -192,6 +192,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputOptionalNumberFormatter]
 		}),
 		new web3._extend.Method({
+			name: 'verbosityTraceFloor',
+			call: 'debug_verbosityTraceFloor',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputOptionalNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'vmodule',
 			call: 'debug_vmodule',
 			params: 1,

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -473,7 +473,8 @@ func init() {
 
 	// Default stderrThreshold is ERROR.
 	logging.stderrThreshold = errorLog
-	logging.setVState(3, nil, false)
+	logging.setVState(2, nil, false)
+	logging.vmodule.Set("cmd/geth/*=3")
 	go logging.flushDaemon()
 }
 

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -471,12 +471,10 @@ func init() {
 	// Default stderrThreshold is ERROR.
 	logging.stderrThreshold = errorLog
 	// Establish defaults for trace thresholds.
-	logging.verbosityTraceThreshold.set(5)
+	logging.verbosityTraceThreshold.set(0)
 	logging.severityTraceThreshold.set(2)
 	// Default for verbosity.
-	logging.setVState(2, nil, false)
-	// Default for vmodule.
-	logging.vmodule.Set("cmd/geth/*=3")
+	logging.setVState(3, nil, false)
 	go logging.flushDaemon()
 }
 

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -684,9 +684,8 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 	buf.twoDigits(12, second)
 	buf.tmp[14] = '.'
 	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
-	buf.tmp[21] = ' '
-	buf.Write(buf.tmp[:22])
-	buf.WriteString(severityColorReset)
+	buf.Write(buf.tmp[:21])
+	buf.WriteString(severityColorReset + " ")
 	if l.traceThreshold(s) {
 		buf.WriteString(file)
 		buf.tmp[0] = ':'
@@ -694,10 +693,11 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 		buf.tmp[n+1] = ']'
 		buf.tmp[n+2] = ' '
 		buf.Write(buf.tmp[:n+3])
-	} else {
-		buf.tmp[0] = ' '
-		buf.Write(buf.tmp[:1])
 	}
+	//else {
+	//	buf.tmp[0] = ' '
+	//	buf.Write(buf.tmp[:1])
+	//}
 
 	return buf
 }

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -590,7 +590,7 @@ where the fields are defined as follows:
 	line             The line number
 	msg              The user-supplied message
 */
-func (l *loggingT) header(s severity, depth int) (*buffer, string, int) {
+func (l *loggingT) header(s severity, depth int, wantTrace bool) (*buffer, string, int) {
 	_, file, line, ok := runtime.Caller(3 + depth)
 	if !ok {
 		file = "???"
@@ -605,11 +605,11 @@ func (l *loggingT) header(s severity, depth int) (*buffer, string, int) {
 		}
 		file = file[1:] // drop '/'
 	}
-	return l.formatHeader(s, file, line), file, line
+	return l.formatHeader(s, file, line,wantTrace), file, line
 }
 
 // formatHeader formats a log header using the provided file name and line number.
-func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
+func (l *loggingT) formatHeader(s severity, file string, line int, wantTrace bool) *buffer {
 	now := timeNow()
 	if line < 0 {
 		line = 0 // not a real line number, but acceptable to someDigits
@@ -637,7 +637,7 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
 	buf.tmp[21] = ' '
 	buf.Write(buf.tmp[:22])
-	if int(s) > 0 {
+	if wantTrace {
 		buf.WriteString(file)
 		buf.tmp[0] = ':'
 		n := buf.someDigits(1, line)
@@ -645,9 +645,8 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 		buf.tmp[n+2] = ' '
 		buf.Write(buf.tmp[:n+3])
 	} else {
-		buf.tmp[0] = ']'
-		buf.tmp[1] = ' '
-		buf.Write(buf.tmp[:2])
+		buf.tmp[0] = ' '
+		buf.Write(buf.tmp[:1])
 	}
 
 	return buf
@@ -695,7 +694,7 @@ func (buf *buffer) someDigits(i, d int) int {
 }
 
 func (l *loggingT) println(s severity, args ...interface{}) {
-	buf, file, line := l.header(s, 0)
+	buf, file, line := l.header(s, 0, true)
 	fmt.Fprintln(buf, args...)
 	l.output(s, buf, file, line, false)
 }
@@ -705,7 +704,7 @@ func (l *loggingT) print(s severity, args ...interface{}) {
 }
 
 func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
-	buf, file, line := l.header(s, depth)
+	buf, file, line := l.header(s, depth, true)
 	fmt.Fprint(buf, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -714,7 +713,7 @@ func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
 }
 
 func (l *loggingT) printfmt(s severity, format string, args ...interface{}) {
-	buf, file, line := l.header(s, 0)
+	buf, file, line := l.header(s, 0, true)
 	fmt.Fprintf(buf, format, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -722,11 +721,11 @@ func (l *loggingT) printfmt(s severity, format string, args ...interface{}) {
 	l.output(s, buf, file, line, false)
 }
 
-// printWithFileLine behaves like print but uses the provided file and line number.  If
+// printWithOptionalFileLine behaves like print but uses the provided file and line number.  If
 // alsoLogToStderr is true, the log message always appears on standard error; it
 // will also appear in the log file unless --logtostderr is set.
-func (l *loggingT) printWithFileLine(s severity, file string, line int, alsoToStderr bool, args ...interface{}) {
-	buf := l.formatHeader(s, file, line)
+func (l *loggingT) printWithOptionalFileLine(s severity, file string, line int, alsoToStderr bool, wantTrace bool, args ...interface{}) {
+	buf := l.formatHeader(s, file, line, wantTrace)
 	fmt.Fprint(buf, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -1010,9 +1009,10 @@ func (lb logBridge) Write(b []byte) (n int, err error) {
 			line = 1
 		}
 	}
-	// printWithFileLine with alsoToStderr=true, so standard log messages
+	// printWithOptionalFileLine with alsoToStderr=true, so standard log messages
 	// always appear on standard error.
-	logging.printWithFileLine(severity(lb), file, line, true, text)
+
+	logging.printWithOptionalFileLine(severity(lb), file, line, true, int(logging.verbosity) > 4, text)
 	return len(b), nil
 }
 
@@ -1083,6 +1083,7 @@ func V(level Level) Verbose {
 	return Verbose(false)
 }
 
+// INFO
 // Info is equivalent to the global Info function, guarded by the value of v.
 // See the documentation of V for usage.
 func (v Verbose) Info(args ...interface{}) {
@@ -1106,6 +1107,33 @@ func (v Verbose) Infof(format string, args ...interface{}) {
 		logging.printfmt(infoLog, format, args...)
 	}
 }
+
+// WARN
+// Warn is equivalent to the global Warn function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Warn(args ...interface{}) {
+	if v {
+		logging.print(warningLog, args...)
+	}
+}
+
+// Warnln is equivalent to the global Warnln function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Warnln(args ...interface{}) {
+	if v {
+		logging.println(warningLog, args...)
+	}
+}
+
+// Warnf is equivalent to the global Warnf function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Warnf(format string, args ...interface{}) {
+	if v {
+		logging.printfmt(warningLog, format, args...)
+	}
+}
+
+
 
 // Separator creates a line, ie ---------------------------------
 func Separator(iterable string) string {

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -694,7 +694,7 @@ func (buf *buffer) someDigits(i, d int) int {
 }
 
 func (l *loggingT) println(s severity, args ...interface{}) {
-	buf, file, line := l.header(s, 0, true)
+	buf, file, line := l.header(s, 0, logging.verbosity > 4)
 	fmt.Fprintln(buf, args...)
 	l.output(s, buf, file, line, false)
 }
@@ -704,7 +704,7 @@ func (l *loggingT) print(s severity, args ...interface{}) {
 }
 
 func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
-	buf, file, line := l.header(s, depth, true)
+	buf, file, line := l.header(s, depth, logging.verbosity > 4)
 	fmt.Fprint(buf, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -713,7 +713,7 @@ func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
 }
 
 func (l *loggingT) printfmt(s severity, format string, args ...interface{}) {
-	buf, file, line := l.header(s, 0, true)
+	buf, file, line := l.header(s, 0, logging.verbosity > 4)
 	fmt.Fprintf(buf, format, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -636,8 +636,8 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 	buf.tmp[14] = '.'
 	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
 	buf.tmp[21] = ' '
+	buf.Write(buf.tmp[:22])
 	if int(s) > 0 {
-		buf.Write(buf.tmp[:22])
 		buf.WriteString(file)
 		buf.tmp[0] = ':'
 		n := buf.someDigits(1, line)

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -636,13 +636,20 @@ func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
 	buf.tmp[14] = '.'
 	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
 	buf.tmp[21] = ' '
-	buf.Write(buf.tmp[:22])
-	buf.WriteString(file)
-	buf.tmp[0] = ':'
-	n := buf.someDigits(1, line)
-	buf.tmp[n+1] = ']'
-	buf.tmp[n+2] = ' '
-	buf.Write(buf.tmp[:n+3])
+	if int(s) > 0 {
+		buf.Write(buf.tmp[:22])
+		buf.WriteString(file)
+		buf.tmp[0] = ':'
+		n := buf.someDigits(1, line)
+		buf.tmp[n+1] = ']'
+		buf.tmp[n+2] = ' '
+		buf.Write(buf.tmp[:n+3])
+	} else {
+		buf.tmp[0] = ']'
+		buf.tmp[1] = ' '
+		buf.Write(buf.tmp[:2])
+	}
+
 	return buf
 }
 


### PR DESCRIPTION
### problem
Normal logging is kind of "noisy," as @splix complains in #410. With that in mind, making logs "pretty" also removes important debugging information. 

### solution
Makes pretty logs when a single flag `--pretty` is used. The reason I used __opt-in__ prettiness in 199652e is because I believe geth should use defaults that are most useful for developers. While indeed it's important for beginners and laymen to have access to an approachable interface, I t hink we'd be shooting ourselves in the foot (it's hard enough getting issue contributors to include _any_ logs) and moving away from a "technology first" principle by establishing a default prioritizing the 💄 before the 🔧 .

With that said, there's very little I love more than a good interface.  There's still a long way to go IMO with formatting the STATUS logs, adding possible other STATUS logs besides `SYNC`, and improving the design of the non-textual visual interface (eg. domino effect); but this is a start.

![screen shot 2017-11-27 at 13 07 39](https://user-images.githubusercontent.com/10228550/33253009-fe9e7a62-d373-11e7-8fc4-fe753855821c.png)

_note here that I'm overriding `--log-status` interval manually; the default for --pretty is `sync=15 [seconds]`_

### solve specs
- only `verbosity=error` lines are shown
- `geth` still logs normal configuration stuff on startup
- file traces will be excluded unless `debug.verbosity(5)` is used to set verbosity on the fly (like if user is experiencing some weirdness or just wants a closer look for whatever reason) OR if `debug.verbosityTraceFloor(1)` is used to set the minimum global verbosity threshold determining if file traces should be included
- status logs will be dispatched every 15 seconds, including a new block progress display I call __the domino effect__ 🃏 

__All of these defaults can be overridden manually with their respective flags.__

Further, in case of `severity=error` or `severity=fatal`, the calling file trace will always be shown.

As explained in `geth help`:
```
  --pretty							Use pretty defaults for logging (verbosity=1,vmodule='cmd/geth/*=3',verbosity-trace-floor=5,log-status='sync=15')
```

### how it works
As-is, there are two "dimensions" of logging: `verbosity` and `severity`. 
- _Verbosity_ means "how much to say." It scales the granularity and detail of reporting. 
- _Severity_ means "how to say it." It scales the _importance_, _relative to verbosity_. 

> - [ ] TODO: explain this more

The __domino effect__ uses the number of dominos to represent the number of blocks imported since last log, and the domino dot-number to represent number of transactions per block (_eg_ 🁣 = 0 txs, 🂓 = 12+ txs). Representing blocks imported and txs are currently simply 1:1 with actual blocks/txs, but eventually should be scaled dynamically (with a _log function_... get it?) based on maximums and the limits of reasonable display units, eg. _show no more than 20 dominoes, and if tx count increases a lot lately, use domino 3-dots to represent 9 txs_ or whatever

### changes
- Implement flag `--verbosity-trace-floor` and JSON-API:`debug.verbosityTraceFloor` to set the minimum _global_ verbosity level at which to include file name traces in log line headers, eg. 
```
I1127 13:10:19.130503  imported 1 block(s) (0 queued 0 ignored) including 89 txs in 118.756888ms. #4912033 [024edb99 / 024edb99]
```
vs.
```
I1127 13:09:59.359355 core/blockchain.go:1514] imported 1 block(s) (0 queued 0 ignored) including 2 txs in 8.742389ms. #4912032 [66839ff4 / 66839ff4]
```

- Enable `glog.formatHeader` to use verbosity and severity thresholds for including file traces in the headers
- Implement flag `--pretty` to toggle pretty default log settings, all of which can be overridden manually with their own flags.
- Implement missing `glog.Verbosity#Warn[|ln|f]` and `glog.Verbosity#Error[|ln|f]` methods for using severity with verbosity in logging.
- Establish default of `>= severity.error` for including file traces. Important for debugging and reporting bugs.

----

- [ ] update tests