### PR TITLE
CI: deploy on tags as well as master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,16 @@ script:
 # Run bats integration tests.
 - bats cmd/geth
 
+# Deploy on either branch=master or tags=true. Identical process, different conditions.
+# https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
 deploy:
-  skip_cleanup: true
-  provider: script
-  script: ./deploy.sh
-  on:
-    branch: master
-  tags: true
+  - provider: script
+    skip_cleanup: true
+    script: ./deploy.sh
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: ./deploy.sh
+    on:
+      tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ before_deploy:
 # Deploy on APPVEYOR_REPO_BRANCH=master or APPVEYOR_REPO_TAG=true
 deploy_script:
   - ps: >-
-      If (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG)) {
+      If (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true')) {
         janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
       }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,10 @@ before_deploy:
   # Set up GCP upload.
   - nuget install secure-file -ExcludeVersion
   - secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
+# Deploy on APPVEYOR_REPO_BRANCH=master or APPVEYOR_REPO_TAG=true
 deploy_script:
   - ps: >-
-      If ($env:APPVEYOR_REPO_BRANCH -eq 'master') {
+      If (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG)) {
         janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
       }
 


### PR DESCRIPTION
### problem
The CIs are currently set to deploy only when `branch=master`. Both Travis and Appveyor consider tags as branches for their environment settings. So building from a tagged commit yields `branch=4.1.2`, which is not considered deployable.

The current solution for this is to restart the `branch=master` builds once the tag has been pushed, or to merge locally, tag, push tag, then finally push merge. Both are rather annoying and seem kind of backwards.

### solution
- travis: add identical deployment providers with different conditions (see link)
- appveyor: use ps deployment conditional to check for `APPVEYOR_REPO_BRANCH<string>=master` OR `APPVEYOR_REPO_TAG<string?>`

Noting:
https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
