### PR TITLE
make rotateOld thread safe

### DIFF
--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -223,6 +223,7 @@ func SetToStderr(toStderr bool) {
 // for logging to both FS and stderr.
 func SetAlsoToStderr(to bool) {
 	logging.mu.Lock()
+
 	logging.alsoToStderr = to
 	logging.mu.Unlock()
 }
@@ -1050,7 +1051,12 @@ func gzipFile(name string) error {
 	return os.Remove(name)
 }
 
+var rotationMutex sync.Mutex
+
 func (sb *syncBuffer) rotateOld(now time.Time) {
+	rotationMutex.Lock()
+	defer rotationMutex.Unlock()
+
 	logs, err := getLogFiles()
 	if err != nil {
 		Fatal(err)

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -1054,42 +1054,42 @@ func gzipFile(name string) error {
 var rotationTime int64
 
 func (sb *syncBuffer) rotateOld(now time.Time) {
-	nanos := now.UnixNano()
-	if atomic.CompareAndSwapInt64(&rotationTime, 0, nanos) {
-		logs, err := getLogFiles()
-		if err != nil {
-			Fatal(err)
-		}
-
-		logs = excludeActive(logs)
-
-		logs, err = removeOutdated(logs, now)
-		if err != nil {
-			Fatal(err)
-		}
-
-		logs, err = compressOrphans(logs)
-		if err != nil {
-			Fatal(err)
-		}
-
-		if MaxTotalSize > MaxSize {
-			totalSize := getTotalSize(logs)
-			for i := 0; i < len(logs) && totalSize > MaxTotalSize-MaxSize; i++ {
-				err := os.Remove(filepath.Join(logs[i].dir, logs[i].name))
-				if err != nil {
-					Fatal(err)
-				}
-				totalSize -= logs[i].size
-			}
-		}
-
-		if current := atomic.SwapInt64(&rotationTime, 0); current > nanos {
-			go sb.rotateOld(time.Unix(0, current))
-		}
-	} else {
-		atomic.StoreInt64(&rotationTime, nanos)
+	//nanos := now.UnixNano()
+	//if atomic.CompareAndSwapInt64(&rotationTime, 0, nanos) {
+	logs, err := getLogFiles()
+	if err != nil {
+		Fatal(err)
 	}
+
+	logs = excludeActive(logs)
+
+	logs, err = removeOutdated(logs, now)
+	if err != nil {
+		Fatal(err)
+	}
+
+	logs, err = compressOrphans(logs)
+	if err != nil {
+		Fatal(err)
+	}
+
+	if MaxTotalSize > MaxSize {
+		totalSize := getTotalSize(logs)
+		for i := 0; i < len(logs) && totalSize > MaxTotalSize-MaxSize; i++ {
+			err := os.Remove(filepath.Join(logs[i].dir, logs[i].name))
+			if err != nil {
+				Fatal(err)
+			}
+			totalSize -= logs[i].size
+		}
+	}
+
+	//	if current := atomic.SwapInt64(&rotationTime, 0); current > nanos {
+	//		go sb.rotateOld(time.Unix(0, current))
+	//	}
+	//} else {
+	//	atomic.StoreInt64(&rotationTime, nanos)
+	//}
 }
 
 type logFile struct {

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -91,7 +91,7 @@
 // all files except the current one are compressed with GZIP.
 //
 // Rotation works like this:
-//  - if MaxSize or RotaitonInterval is reached, and file size is > MinSize,
+//  - if MaxSize or RotationInterval is reached, and file size is > MinSize,
 //    current file became old file, and new file is created as a current log file
 //  - all log files older than MaxAge are removed
 //  - if compression is enabled, the old file is compressed
@@ -1054,42 +1054,42 @@ func gzipFile(name string) error {
 var rotationTime int64
 
 func (sb *syncBuffer) rotateOld(now time.Time) {
-	//nanos := now.UnixNano()
-	//if atomic.CompareAndSwapInt64(&rotationTime, 0, nanos) {
-	logs, err := getLogFiles()
-	if err != nil {
-		Fatal(err)
-	}
-
-	logs = excludeActive(logs)
-
-	logs, err = removeOutdated(logs, now)
-	if err != nil {
-		Fatal(err)
-	}
-
-	logs, err = compressOrphans(logs)
-	if err != nil {
-		Fatal(err)
-	}
-
-	if MaxTotalSize > MaxSize {
-		totalSize := getTotalSize(logs)
-		for i := 0; i < len(logs) && totalSize > MaxTotalSize-MaxSize; i++ {
-			err := os.Remove(filepath.Join(logs[i].dir, logs[i].name))
-			if err != nil {
-				Fatal(err)
-			}
-			totalSize -= logs[i].size
+	nanos := now.UnixNano()
+	if atomic.CompareAndSwapInt64(&rotationTime, 0, nanos) {
+		logs, err := getLogFiles()
+		if err != nil {
+			Fatal(err)
 		}
-	}
 
-	//	if current := atomic.SwapInt64(&rotationTime, 0); current > nanos {
-	//		go sb.rotateOld(time.Unix(0, current))
-	//	}
-	//} else {
-	//	atomic.StoreInt64(&rotationTime, nanos)
-	//}
+		logs = excludeActive(logs)
+
+		logs, err = removeOutdated(logs, now)
+		if err != nil {
+			Fatal(err)
+		}
+
+		logs, err = compressOrphans(logs)
+		if err != nil {
+			Fatal(err)
+		}
+
+		if MaxTotalSize > MaxSize {
+			totalSize := getTotalSize(logs)
+			for i := 0; i < len(logs) && totalSize > MaxTotalSize-MaxSize; i++ {
+				err := os.Remove(filepath.Join(logs[i].dir, logs[i].name))
+				if err != nil {
+					Fatal(err)
+				}
+				totalSize -= logs[i].size
+			}
+		}
+
+		if current := atomic.SwapInt64(&rotationTime, 0); current > nanos {
+			go sb.rotateOld(time.Unix(0, current))
+		}
+	} else {
+		atomic.StoreInt64(&rotationTime, nanos)
+	}
 }
 
 type logFile struct {

--- a/logger/glog/glog_test.go
+++ b/logger/glog/glog_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	stdLog "log"
+	//"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	//"sync"
 	"testing"
 	"time"
 )
@@ -734,6 +736,86 @@ func TestParseInterval(t *testing.T) {
 		})
 	}
 }
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+/*
+// Following code is commented-out because the test depends very strongly on
+// time and performance. On my (tzdybal) machine currently hardcoded parameters
+// was used to reproduce the problem with parallel execution of rotateOld.
+
+// See: https://stackoverflow.com/a/31832326/3474438
+func RandStringBytesMaskImprSrc(n int, src rand.Source) []byte {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return b
+}
+
+func TestLongRunningRotateOld(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	start := time.Date(2017, time.December, 06, 0, 0, 0, 0, time.UTC)
+
+	fileSize := 100 * 1024 * 1024
+
+	logDate := start
+	// generate files
+	var src = rand.NewSource(time.Now().UnixNano())
+	for i := 0; i < 5; i++ {
+		infoF, infoL := logName("INFO", logDate.Add(1*time.Second))
+
+		ioutil.WriteFile(filepath.Join(dir, infoF), RandStringBytesMaskImprSrc(fileSize, src), 0600)
+
+		infoSL := filepath.Join(dir, infoL)
+		os.Remove(infoSL)                             // ignore err
+		os.Symlink(filepath.Join(dir, infoF), infoSL) // ignore err
+
+		logDate = logDate.Add(24 * time.Hour)
+	}
+
+	// prepare environment
+	logDirs = nil
+	SetLogDir(dir)
+	createLogDirs()
+
+	// execute rotation
+	sb := &syncBuffer{}
+
+	wg := sync.WaitGroup{}
+
+	run := func() {
+		wg.Add(1)
+		defer wg.Done()
+		sb.rotateOld(logDate)
+	}
+
+	go run()
+	time.Sleep(5 * time.Second)
+	go run()
+
+	wg.Wait()
+}
+*/
 
 func BenchmarkHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
problem: when rotation of old files take a long time (compression is
turned on, there are lots of large old files to rotate, etc) and there
is new rotation request (current log file size or time based) it is
possible, that rotateOld will be executed twice in parallel, and list
of files gathered in one execution can be outdated by changes made by
another execution.

comment: log handling is very conservative to avoid any loss of logs.
If there is a problem with opening a file (for example for compression),
fatal error is reported.
Following KISS principle, mutex is added to protect the entire rotateOld.