### PR TITLE
allow GOMAXPROCS to be set with env var

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -22,8 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
-
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/ethereumproject/go-ethereum/console"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -237,10 +237,6 @@ func makeCLIApp() (app *cli.App) {
 			}
 		}
 
-		if os.Getenv("GOMAXPROCS") == "" {
-			runtime.GOMAXPROCS(runtime.NumCPU())
-		}
-
 		err := setupLogRotation(ctx)
 		if err != nil {
 			return err

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -237,7 +237,9 @@ func makeCLIApp() (app *cli.App) {
 			}
 		}
 
-		runtime.GOMAXPROCS(runtime.NumCPU())
+		if os.Getenv("GOMAXPROCS") == "" {
+			runtime.GOMAXPROCS(runtime.NumCPU())
+		}
 
 		err := setupLogRotation(ctx)
 		if err != nil {


### PR DESCRIPTION
### problem
geth always uses `runtime.GOMAXPROCS(runtime.NumCPU())` which doesn't allow user to override `GOMAXPROCS` value with environment variable.

### solution
only set runtime.GOMAXPROCS if GOMAXPROCS env var is not set

This allows user to override go max procs config with `env GOMAXPROCS=n geth [...]` instead of geth demanding to use number of available CPUs on machine.