### PR TITLE
Ensure that gzipped log file is fsync'ed before removing plain log

### DIFF
--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -1044,6 +1044,9 @@ func gzipFile(name string) error {
 	if err = writer.Flush(); err != nil {
 		return err
 	}
+	if err = gzipped.Sync(); err != nil {
+		return err
+	}
 	if err = gzipped.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Small change to improve durability of logging.