### PR TITLE
fix: data race at mlog#SetDetailValues

### DIFF
--- a/logger/mlog_file.go
+++ b/logger/mlog_file.go
@@ -475,15 +475,20 @@ func (m *MLogDetailT) AsDocumentation() *MLogDetailT {
 // Arguments MUST be provided in the order in which they should be applied to the
 // slice of existing details.
 func (m MLogT) SetDetailValues(detailVals ...interface{}) MLogT {
-
 	// Check for congruence between argument length and registered details.
 	if len(detailVals) != len(m.Details) {
-		glog.Fatal("mlog: wrong number of details set, want: ", len(m.Details), "got:", len(detailVals))
+		glog.Fatal(m.EventName(), "wrong number of details set, want: ", len(m.Details), "got:", len(detailVals))
 	}
 
+	// Use intermediate array to handle setting values, avoids data race conditions.
+	var tmpDetails = make([]MLogDetailT, len(m.Details))
+	copy(tmpDetails, m.Details)
+
 	for i, detailval := range detailVals {
-		m.Details[i].Value = detailval
+		tmpDetails[i].Value = detailval
 	}
+	m.Details = tmpDetails
+	tmpDetails = nil // garbage
 
 	return m
 }

--- a/logger/mlog_file_test.go
+++ b/logger/mlog_file_test.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"testing"
+)
+
+// mlogNeighborsHandleFrom is called once for each neighbors request from a node FROM
+var mlogExampleT = MLogT{
+	Description: `Struct for testing mlog structs.`,
+	Receiver:    "TESTER",
+	Verb:        "TESTING",
+	Subject:     "MLOG",
+	Details: []MLogDetailT{
+		{"FROM", "UDP_ADDRESS", "STRING"},
+		{"FROM", "ID", "STRING"},
+		{"NEIGHBORS", "BYTES_TRANSFERRED", "INT"},
+	},
+}
+
+func BenchmarkSetDetailValues(b *testing.B) {
+	vals := []interface{}{"hello", "kitty", 42}
+	for i := 0; i < b.N; i++ {
+		mlogExampleT.SetDetailValues(vals...)
+	}
+}


### PR DESCRIPTION
Fixes #442 

The only thing I don't like about it is that it takes ~`275ns` instead of ~`45ns` per op