### PR TITLE
downgrade rustup to nonbroken version for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,10 @@ install:
   - ps: $env:VERSION = "$(janus.exe version -format='TAG_OR_NIGHTLY')"
 
   # Install Rust.
-  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  # Downgrade to use older, not-currently-broken version.
+  - appveyor DownloadFile https://static.rust-lang.org/rustup/archive/1.7.0/i686-pc-windows-gnu/rustup-init.exe -FileName rustup-init.exe
+  # Currently broken version.
+  # - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain stable --default-host x86_64-pc-windows-gnu
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustup update


### PR DESCRIPTION
just taken verbatim from https://github.com/rust-lang-nursery/rustup.rs/issues/1316#issuecomment-354156348

we can revert this change once the rustup issue has been resolved. but for now a requirement for us to be able to get builds to pass so we can merge stuff.