### PR TITLE
problem: synchronous log compression

### DIFF
--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -991,9 +991,6 @@ func (sb *syncBuffer) rotateCurrent(now time.Time) error {
 	if sb.file != nil {
 		sb.Flush()
 		sb.file.Close()
-		if Compress {
-			gzipFile(sb.file.Name())
-		}
 	}
 	var err error
 	sb.file, _, err = create(severityName[sb.sev], now)


### PR DESCRIPTION
solution: remove log compression from `rotateCurrent` function, latest
file will be compressed anyways during normal run of `ratateOld`
function. This removes race condition (two goroutines trying to compress
same file) and eliminates the problem that logs are suspended for time
necessary to compress large file (may took many seconds)