### PR TITLE
implement default Version name with git if ldflags not set

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -112,3 +112,4 @@
 [[constraint]]
   name = "gopkg.in/urfave/cli.v1"
   revision = "01857ac33766ce0c93856370626f9799281c14f4"
+

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -29,11 +29,34 @@ import (
 	"github.com/ethereumproject/go-ethereum/eth"
 	"github.com/ethereumproject/go-ethereum/logger"
 	"github.com/ethereumproject/go-ethereum/metrics"
+	"runtime"
+	"os/exec"
 )
 
 // Version is the application revision identifier. It can be set with the linker
 // as in: go build -ldflags "-X main.Version="`git describe --tags`
 var Version = "source"
+
+// setVersionIfDefaulty uses jansu
+func setVersionIfDefaulty() {
+	// If building from source without tags, use janus to get a formatted version to be more descriptive
+	if Version == "source" {
+		// Get the path of this file
+		_, f, _, ok := runtime.Caller(1)
+		if ok {
+			d := filepath.Dir(f) // ./cmd/geth
+			d = filepath.Join(d, "..", "..", ".git")
+			if o, err := exec.Command("git", "--git-dir", d, "describe", "--tags").Output(); err == nil {
+				// Ignore error
+				Version = "source_" + string(o)
+			}
+		}
+	}
+}
+
+func init() {
+	setVersionIfDefaulty()
+}
 
 func makeCLIApp() (app *cli.App) {
 	app = cli.NewApp()

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -19,38 +19,38 @@ package main
 
 import (
 	"fmt"
+	"gopkg.in/urfave/cli.v1"
 	"log"
 	"os"
 	"path/filepath"
-	"gopkg.in/urfave/cli.v1"
 
 	"github.com/ethereumproject/go-ethereum/console"
 	"github.com/ethereumproject/go-ethereum/core"
 	"github.com/ethereumproject/go-ethereum/eth"
 	"github.com/ethereumproject/go-ethereum/logger"
 	"github.com/ethereumproject/go-ethereum/metrics"
-	"runtime"
 	"os/exec"
 	"regexp"
+	"runtime"
 )
 
 // Version is the application revision identifier. It can be set with the linker
 // as in: go build -ldflags "-X main.Version="`git describe --tags`
 var Version = "source"
 
-// setVersionIfDefaulty uses jansu
+// setVersionIfDefaulty uses git to derive a meaningful version value if not set/overridden by -ldflags
 func setVersionIfDefaulty() {
-	// If building from source without tags, use janus to get a formatted version to be more descriptive
 	if Version == "source" {
 		// Get the path of this file
 		_, f, _, ok := runtime.Caller(1)
 		if ok {
-			d := filepath.Dir(f) // ./cmd/geth
+			d := filepath.Dir(f) // .../cmd/geth
+			// Derive git project dir
 			d = filepath.Join(d, "..", "..", ".git")
 			// Ignore error
 			if o, err := exec.Command("git", "--git-dir", d, "describe", "--tags").Output(); err == nil {
 				// Remove newline
-				re := regexp.MustCompile(`\r?\n`) // handle both Windows carriage returns and *nix newlines.
+				re := regexp.MustCompile(`\r?\n`) // Handle both Windows carriage returns and *nix newlines
 				Version = "source_" + re.ReplaceAllString(string(o), "")
 			}
 		}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/metrics"
 	"runtime"
 	"os/exec"
+	"regexp"
 )
 
 // Version is the application revision identifier. It can be set with the linker
@@ -46,9 +47,11 @@ func setVersionIfDefaulty() {
 		if ok {
 			d := filepath.Dir(f) // ./cmd/geth
 			d = filepath.Join(d, "..", "..", ".git")
+			// Ignore error
 			if o, err := exec.Command("git", "--git-dir", d, "describe", "--tags").Output(); err == nil {
-				// Ignore error
-				Version = "source_" + string(o)
+				// Remove newline
+				re := regexp.MustCompile(`\r?\n`) // handle both Windows carriage returns and *nix newlines.
+				Version = "source_" + re.ReplaceAllString(string(o), "")
 			}
 		}
 	}

--- a/cmd/geth/main_test.go
+++ b/cmd/geth/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+	"strings"
+)
+
+// TestSetVersionIfFromSourceWithOverride checks the conditional in the init fn.
+func TestSetVersionIfFromSource(t *testing.T) {
+	expectedSetVersionPrefix := "source_v"
+
+	// Ensure if Version override; check fn functionality.
+	Version = "source"
+	setVersionIfDefaulty()
+	if Version == "source" || !strings.Contains(Version, expectedSetVersionPrefix) {
+		t.Errorf("Build from source did not set version. Got: %v", Version)
+	} else {
+		// Log for visual clarity and confirmation
+		t.Log("OK: source version=", Version)
+	}
+
+	customVersion := "custom_ldflags_version"
+	Version = customVersion
+	setVersionIfDefaulty()
+	if Version != customVersion {
+		t.Error("Build from source with -ldflags override for main.Version (nondefaulty)")
+	}
+}

--- a/cmd/geth/main_test.go
+++ b/cmd/geth/main_test.go
@@ -3,13 +3,19 @@ package main
 import (
 	"testing"
 	"strings"
+	"os"
 )
 
 // TestSetVersionIfFromSourceWithOverride checks the conditional in the init fn.
 func TestSetVersionIfFromSource(t *testing.T) {
 	expectedSetVersionPrefix := "source_v"
 
-	// Ensure if Version override; check fn functionality.
+	// Ensure version was set by init fn (without linker flag), it should already not be "source"
+	if !strings.Contains(strings.Join(os.Args, " "), "ldflag") && Version == "source" {
+		t.Errorf("Version should be set to git revision by default, got: %s", Version)
+	}
+
+	// Reset, ensure conditional Version override; double check fn functionality.
 	Version = "source"
 	setVersionIfDefaulty()
 	if Version == "source" || !strings.Contains(Version, expectedSetVersionPrefix) {

--- a/cmd/geth/main_test.go
+++ b/cmd/geth/main_test.go
@@ -19,6 +19,10 @@ func TestSetVersionIfFromSource(t *testing.T) {
 		t.Log("OK: source version=", Version)
 	}
 
+	if strings.Contains(Version, "\\n") || strings.Contains(Version, "\\r") {
+		t.Errorf("Got unwanted newline")
+	}
+
 	customVersion := "custom_ldflags_version"
 	Version = customVersion
 	setVersionIfDefaulty()

--- a/cmd/geth/version.bats
+++ b/cmd/geth/version.bats
@@ -22,14 +22,22 @@ teardown() {
 
     run "$example_out_place/geth" version
     [ "$status" -eq 0 ]
-	[[ "$output" == *"Version: source_v"* ]]
+    [[ "$output" == *"Version: source_v"* ]]
 
     # Ensure moving existing binary does not impact version value.
     mv "$example_out_place/geth" "$another_place"/
+    run "$another_place/geth" version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Version: source_v"* ]]
 
+    # Ensure messing around with source doesn't impact version value for
+    # existing binary.
+    mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/cmd/geth" "$GOPATH/src/github.com/ethereumproject/go-ethereum/geth"
     run "$another_place/geth" version
     [ "$status" -eq 0 ]
 	[[ "$output" == *"Version: source_v"* ]]
+    # put it back
+    mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/geth" "$GOPATH/src/github.com/ethereumproject/go-ethereum/cmd/geth"
 
     # Ensure building from project WD yields expected version value.
     cd "$GOPATH/src/github.com/ethereumproject/go-ethereum"
@@ -40,7 +48,7 @@ teardown() {
 	[[ "$output" == *"Version: source_v"* ]]
     rm ./geth
 
-    # Ensure building from project package WD yields expected version value.
+    # Ensure building from project package 'geth' yields expected version value.
     cd ./cmd/geth
     go build .
     [ -f ./geth ]

--- a/cmd/geth/version.bats
+++ b/cmd/geth/version.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+: ${GETH_CMD:=$GOPATH/bin/geth}
+
+setup() {
+	DATA_DIR=`mktemp -d`
+}
+
+teardown() {
+	rm -fr $DATA_DIR
+}
+
+@test "version sets default from git" {
+
+    local example_out_place=`mktemp -d`
+    local another_place=`mktemp -d`
+
+    # Ensure building from arbitrary CWD to arbitrary DIR/geth yields expected
+    # version value.
+    cd # cwd=$home
+    go build -o "$example_out_place/geth" github.com/ethereumproject/go-ethereum/cmd/geth
+
+    run "$example_out_place/geth" version
+    [ "$status" -eq 0 ]
+	[[ "$output" == *"Version: source_v"* ]]
+
+    # Ensure moving existing binary does not impact version value.
+    mv "$example_out_place/geth" "$another_place"/
+
+    run "$another_place/geth" version
+    [ "$status" -eq 0 ]
+	[[ "$output" == *"Version: source_v"* ]]
+
+    # Ensure building from project WD yields expected version value.
+    cd "$GOPATH/src/github.com/ethereumproject/go-ethereum"
+    go build ./cmd/geth
+    [ -f ./geth ]
+    run ./geth version
+    [ "$status" -eq 0 ]
+	[[ "$output" == *"Version: source_v"* ]]
+    rm ./geth
+
+    # Ensure building from project package WD yields expected version value.
+    cd ./cmd/geth
+    go build .
+    [ -f ./geth ]
+    run ./geth version
+    [ "$status" -eq 0 ]
+	[[ "$output" == *"Version: source_v"* ]]
+    rm ./geth
+
+    # Cleanup
+    rm -rf "$example_out_place"
+    rm -rf "$another_place"
+}
+

--- a/cmd/geth/version.bats
+++ b/cmd/geth/version.bats
@@ -30,6 +30,8 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Version: source_v"* ]]
 
+    ## These next two tests should show that the binary is independent from the
+    # source code from which it was built.
     # Ensure messing around with source doesn't impact version value for
     # existing binary.
     mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/cmd/geth" "$GOPATH/src/github.com/ethereumproject/go-ethereum/geth"
@@ -38,6 +40,17 @@ teardown() {
 	[[ "$output" == *"Version: source_v"* ]]
     # put it back
     mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/geth" "$GOPATH/src/github.com/ethereumproject/go-ethereum/cmd/geth"
+
+    # Ensure messing around with source .git doesn't impact version value for
+    # existing binary. THIS FAILS, so binary is dependent of working source
+    # tree. Weird.
+#    mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/.git" "$GOPATH/src/github.com/ethereumproject/go-ethereum/.notgit"
+#    run "$another_place/geth" version
+#    [ "$status" -eq 0 ]
+#    echo "$output"
+#	[[ "$output" == *"Version: source_v"* ]]
+#    # put it back
+#    mv "$GOPATH/src/github.com/ethereumproject/go-ethereum/.notgit" "$GOPATH/src/github.com/ethereumproject/go-ethereum/.git"
 
     # Ensure building from project WD yields expected version value.
     cd "$GOPATH/src/github.com/ethereumproject/go-ethereum"

--- a/vendor/github.com/ethereumproject/ethash/ethash.go
+++ b/vendor/github.com/ethereumproject/ethash/ethash.go
@@ -257,7 +257,6 @@ func (d *dag) generate() {
 			d.dir = DefaultDir
 		}
 		glog.V(logger.Info).Infof("Generating DAG for epoch %d (size %d) (%x)", d.epoch, dagSize, seedHash)
-		glog.D(logger.Error).Infof("Generating DAG for epoch %d [size %d] (%x)", d.epoch, dagSize, seedHash)
 		// Generate a temporary cache.
 		// TODO: this could share the cache with Light
 		cache := C.ethash_light_new_internal(cacheSize, (*C.ethash_h256_t)(unsafe.Pointer(&seedHash[0])))
@@ -290,7 +289,6 @@ func (d *dag) Ptr() unsafe.Pointer {
 //export ethashGoCallback
 func ethashGoCallback(percent C.unsigned) C.int {
 	glog.V(logger.Info).Infof("Generating DAG: %d%%", percent)
-	glog.D(logger.Error).Infof("Generating DAG: %d%%", percent)
 	return 0
 }
 


### PR DESCRIPTION
#### problem
geth Version = `source` isn't descriptive when having been built from source. For reading debug logs and viewing other connected geth node versions, it would be nice to have a default with more information.

#### solution
Use `git describe --tags` on `cmd/geth/main.go#init()` to set `Version` if it hasn't been already been set by `--ldflags`. 

```shell
⟠ geth version
Geth
Version: source_v4.2.0-3-ge2e95dc
```
```shell
2018-01-09 08:49:58 Geth Classic version: source_v4.2.0-3-ge2e95dc
```
```shell
  name: "Geth/source_v4.2.0-3-ge2e95dc/darwin/go1.9.2",
```

instead of 
```shell
⟠ geth version
Geth
Version: source
```

Although the incoming makefile and make build/install commands will take care of some of this issue by convenience, I think it's still nice to have for any `go build/install` cases.
  
  