### PR TITLE
fix data race at mlog#SetDetailValues

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1295,7 +1295,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 			if parent != nil {
 				parentTimeDiff = new(big.Int).Sub(block.Time(), parent.Time())
 			}
-			mlogBlockchain.Send(mlogBlockchainWriteBlock.SetDetailValues(
+			mlogBlockchainWriteBlock.AssignDetails(
 				mlogWriteStatus,
 				err,
 				block.Number(),
@@ -1309,7 +1309,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 				len(block.Uncles()),
 				block.ReceivedAt,
 				parentTimeDiff,
-			))
+			).Send(mlogBlockchain)
 		}()
 	}
 
@@ -1546,7 +1546,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (chainIndex int, err err
 			latestBlockTime,
 		})
 		if logger.MlogEnabled() {
-			mlogBlockchain.Send(mlogBlockchainInsertBlocks.SetDetailValues(
+			mlogBlockchainInsertBlocks.AssignDetails(
 				stats.processed,
 				stats.queued,
 				stats.ignored,
@@ -1555,7 +1555,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (chainIndex int, err err
 				start.Hash().Hex(),
 				end.Hash().Hex(),
 				tend,
-			))
+			).Send(mlogBlockchain)
 		}
 		glog.V(logger.Info).Infof("imported %d block(s) (%d queued %d ignored) including %d txs in %v. #%v [%s / %s]\n",
 			stats.processed,
@@ -1647,12 +1647,12 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		glog.Infof("Chain split detected @ [%s]. Reorganising chain from #%v %s to %s", commonHash.Hex(), numSplit, oldStart.Hash().Hex(), newStart.Hash().Hex())
 	}
 	if logger.MlogEnabled() {
-		mlogBlockchain.Send(mlogBlockchainReorgBlocks.SetDetailValues(
+		mlogBlockchainReorgBlocks.AssignDetails(
 			commonHash.Hex(),
 			numSplit,
 			oldStart.Hash().Hex(),
 			newStart.Hash().Hex(),
-		))
+		).Send(mlogBlockchain)
 	}
 
 	var addedTxs types.Transactions

--- a/core/mlog.go
+++ b/core/mlog.go
@@ -11,18 +11,18 @@ var mlogTxPool = logger.MLogRegisterAvailable("txpool", mLogLinesTxPool)
 // May be used for automatic mlog documentation generator, or
 // for API usage/display/documentation otherwise.
 var mLogLinesBlockchain = []logger.MLogT{
-	mlogBlockchainWriteBlock,
-	mlogBlockchainInsertBlocks,
+	*mlogBlockchainWriteBlock,
+	*mlogBlockchainInsertBlocks,
 }
 
 var mLogLinesTxPool = []logger.MLogT{
-	mlogTxPoolAddTx,
-	mlogTxPoolValidateTx,
+	*mlogTxPoolAddTx,
+	*mlogTxPoolValidateTx,
 }
 
 // Collect and document available mlog lines.
 
-var mlogBlockchainWriteBlock = logger.MLogT{
+var mlogBlockchainWriteBlock = &logger.MLogT{
 	Description: `Called when a single block written to the chain database.
 A STATUS of NONE means it was written _without_ any abnormal chain event, such as a split.`,
 	Receiver: "BLOCKCHAIN",
@@ -45,7 +45,7 @@ A STATUS of NONE means it was written _without_ any abnormal chain event, such a
 	},
 }
 
-var mlogBlockchainInsertBlocks = logger.MLogT{
+var mlogBlockchainInsertBlocks = &logger.MLogT{
 	Description: "Called when a chain of blocks is inserted into the chain database.",
 	Receiver:    "BLOCKCHAIN",
 	Verb:        "INSERT",
@@ -62,7 +62,7 @@ var mlogBlockchainInsertBlocks = logger.MLogT{
 	},
 }
 
-var mlogBlockchainReorgBlocks = logger.MLogT{
+var mlogBlockchainReorgBlocks = &logger.MLogT{
 	Description: "Called when a chain split is detected and a subset of blocks are reoganized.",
 	Receiver: "BLOCKCHAIN",
 	Verb: "REORG",
@@ -75,7 +75,7 @@ var mlogBlockchainReorgBlocks = logger.MLogT{
 	},
 }
 
-var mlogTxPoolAddTx = logger.MLogT{
+var mlogTxPoolAddTx = &logger.MLogT{
 	Description: `Called once when a valid transaction is added to tx pool.
 $TO.NAME will be the account address hex or '[NEW_CONTRACT]' in case of a contract.`,
 	Receiver: "TXPOOL",
@@ -89,7 +89,7 @@ $TO.NAME will be the account address hex or '[NEW_CONTRACT]' in case of a contra
 	},
 }
 
-var mlogTxPoolValidateTx = logger.MLogT{
+var mlogTxPoolValidateTx = &logger.MLogT{
 	Description: `Called once when validating a single transaction.
 If transaction is invalid, TX.ERROR will be non-nil, otherwise it will be nil.`,
 	Receiver: "TXPOOL",

--- a/core/state/mlog.go
+++ b/core/state/mlog.go
@@ -5,12 +5,12 @@ import "github.com/ethereumproject/go-ethereum/logger"
 var mlogState = logger.MLogRegisterAvailable("state", mlogStateLines)
 
 var mlogStateLines = []logger.MLogT{
-	mlogStateCreateObject,
-	mlogStateAddBalanceObject,
-	mlogStateSubBalanceObject,
+	*mlogStateCreateObject,
+	*mlogStateAddBalanceObject,
+	*mlogStateSubBalanceObject,
 }
 
-var mlogStateCreateObject = logger.MLogT{
+var mlogStateCreateObject = &logger.MLogT{
 	Description: `Called once when a state object is created.
 $OBJECT.NEW is the address of the newly-created object.
 If there was an existing account with the same address, it is overwritten and its address returned as the $OBJECT.PREV value.`,
@@ -23,7 +23,7 @@ If there was an existing account with the same address, it is overwritten and it
 	},
 }
 
-var mlogStateAddBalanceObject = logger.MLogT{
+var mlogStateAddBalanceObject = &logger.MLogT{
 	Description: "Called once when the balance of an account (state object) is added to.",
 	Receiver:    "STATE",
 	Verb:        "ADD_BALANCE",
@@ -36,7 +36,7 @@ var mlogStateAddBalanceObject = logger.MLogT{
 	},
 }
 
-var mlogStateSubBalanceObject = logger.MLogT{
+var mlogStateSubBalanceObject = &logger.MLogT{
 	Description: "Called once when the balance of an account (state object) is subtracted from.",
 	Receiver:    "STATE",
 	Verb:        "SUB_BALANCE",

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -227,12 +227,12 @@ func (c *StateObject) AddBalance(amount *big.Int) {
 	}
 	c.SetBalance(new(big.Int).Add(c.Balance(), amount))
 	if logger.MlogEnabled() {
-		mlogState.Send(mlogStateAddBalanceObject.SetDetailValues(
+		mlogStateAddBalanceObject.AssignDetails(
 			c.Address().Hex(),
 			c.Nonce(),
 			c.Balance(),
 			amount,
-		))
+		).Send(mlogState)
 	}
 	if glog.V(logger.Detail) {
 		glog.Infof("%x: #%d %v (+ %v)\n", c.Address(), c.Nonce(), c.Balance(), amount)
@@ -245,12 +245,12 @@ func (c *StateObject) SubBalance(amount *big.Int) {
 	}
 	c.SetBalance(new(big.Int).Sub(c.Balance(), amount))
 	if logger.MlogEnabled() {
-		mlogState.Send(mlogStateSubBalanceObject.SetDetailValues(
+		mlogStateSubBalanceObject.AssignDetails(
 			c.Address().Hex(),
 			c.Nonce(),
 			c.Balance(),
 			amount,
-		))
+		).Send(mlogState)
 	}
 	if glog.V(logger.Detail) {
 		glog.Infof("%x: #%d %v (- %v)\n", c.Address(), c.Nonce(), c.Balance(), amount)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -428,10 +428,10 @@ func (self *StateDB) createObject(addr common.Address) (newobj, prev *StateObjec
 	newobj.setNonce(StartingNonce) // sets the object to dirty
 	if prev == nil {
 		if logger.MlogEnabled() {
-			mlogState.Send(mlogStateCreateObject.SetDetailValues(
+			mlogStateCreateObject.AssignDetails(
 				newobj.address.Hex(),
 				prev,
-			))
+			).Send(mlogState)
 		}
 		if glog.V(logger.Detail) {
 			glog.Infof("(+) %x\n", addr)
@@ -439,10 +439,10 @@ func (self *StateDB) createObject(addr common.Address) (newobj, prev *StateObjec
 		self.journal = append(self.journal, createObjectChange{account: &addr})
 	} else {
 		if logger.MlogEnabled() {
-			mlogState.Send(mlogStateCreateObject.SetDetailValues(
+			mlogStateCreateObject.AssignDetails(
 				newobj.address.Hex(),
 				prev.address.Hex(),
-			))
+			).Send(mlogState)
 		}
 		self.journal = append(self.journal, resetObjectChange{prev: prev})
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -226,10 +226,10 @@ func (pool *TxPool) SetLocal(tx *types.Transaction) {
 func (pool *TxPool) validateTx(tx *types.Transaction) (e error) {
 	local := pool.localTx.contains(tx.Hash())
 	defer func() {
-		mlogTxPool.Send(mlogTxPoolValidateTx.SetDetailValues(
+		mlogTxPoolValidateTx.AssignDetails(
 			tx.Hash().Hex(),
 			e,
-		))
+		).Send(mlogTxPool)
 	}()
 	// Drop transactions under our own minimal accepted gas price
 	if !local && pool.minGasPrice.Cmp(tx.GasPrice()) > 0 {
@@ -319,12 +319,12 @@ func (self *TxPool) add(tx *types.Transaction) error {
 	from := common.Bytes2Hex(f[:4])
 
 	if logger.MlogEnabled() {
-		mlogTxPool.Send(mlogTxPoolAddTx.SetDetailValues(
+		mlogTxPoolAddTx.AssignDetails(
 			f.Hex(),
 			toLogName,
 			tx.Value,
 			hash.Hex(),
-		))
+		).Send(mlogTxPool)
 	}
 	if glog.V(logger.Debug) {
 		glog.Infof("(t) %x => %s (%v) %x\n", from, toName, tx.Value, hash)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -275,11 +275,11 @@ func (d *Downloader) RegisterPeer(id string, version int, name string, currentHe
 	var err error
 	defer func() {
 		if logger.MlogEnabled() {
-			mlogDownloader.Send(mlogDownloaderRegisterPeer.SetDetailValues(
+			mlogDownloaderRegisterPeer.AssignDetails(
 				id,
 				version,
 				err,
-			))
+			).Send(mlogDownloader)
 		}
 	}()
 
@@ -302,10 +302,10 @@ func (d *Downloader) UnregisterPeer(id string) error {
 	var err error
 	defer func() {
 		if logger.MlogEnabled() {
-			mlogDownloader.Send(mlogDownloaderUnregisterPeer.SetDetailValues(
+			mlogDownloaderUnregisterPeer.AssignDetails(
 				id,
 				err,
-			))
+			).Send(mlogDownloader)
 		}
 	}()
 
@@ -1537,11 +1537,11 @@ func (d *Downloader) qosTuner() {
 		// Log the new QoS values and sleep until the next RTT
 		ttl := d.requestTTL()
 		if logger.MlogEnabled() {
-			mlogDownloader.Send(mlogDownloaderTuneQOS.SetDetailValues(
+			mlogDownloaderTuneQOS.AssignDetails(
 				rtt,
 				float64(conf)/1000000.0,
 				ttl,
-			))
+			).Send(mlogDownloader)
 		}
 		glog.V(logger.Debug).Infof("Quality of service: rtt %v, conf %.3f, ttl %v", rtt, float64(conf)/1000000.0, ttl)
 

--- a/eth/downloader/mlog.go
+++ b/eth/downloader/mlog.go
@@ -5,12 +5,12 @@ import "github.com/ethereumproject/go-ethereum/logger"
 var mlogDownloader = logger.MLogRegisterAvailable("downloader", mLogLines)
 
 var mLogLines = []logger.MLogT{
-	mlogDownloaderRegisterPeer,
-	mlogDownloaderUnregisterPeer,
-	mlogDownloaderTuneQOS,
+	*mlogDownloaderRegisterPeer,
+	*mlogDownloaderUnregisterPeer,
+	*mlogDownloaderTuneQOS,
 }
 
-var mlogDownloaderRegisterPeer = logger.MLogT{
+var mlogDownloaderRegisterPeer = &logger.MLogT{
 	Description: "Called when the downloader registers a peer.",
 	Receiver:    "DOWNLOADER",
 	Verb:        "REGISTER",
@@ -22,7 +22,7 @@ var mlogDownloaderRegisterPeer = logger.MLogT{
 	},
 }
 
-var mlogDownloaderUnregisterPeer = logger.MLogT{
+var mlogDownloaderUnregisterPeer = &logger.MLogT{
 	Description: "Called when the downloader unregisters a peer.",
 	Receiver:    "DOWNLOADER",
 	Verb:        "UNREGISTER",
@@ -33,7 +33,7 @@ var mlogDownloaderUnregisterPeer = logger.MLogT{
 	},
 }
 
-var mlogDownloaderTuneQOS = logger.MLogT{
+var mlogDownloaderTuneQOS = &logger.MLogT{
 	Description: `Called at intervals to gather peer latency statistics. Estimates request round trip time.
 
 RTT reports the estimated Request Round Trip time, confidence is measures from 0-1 (1 is ultimately confidenct),

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -335,12 +335,12 @@ func (f *Fetcher) loop() {
 			if notification.number > 0 {
 				if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
 					if logger.MlogEnabled() {
-						mlogFetcher.Send(mlogFetcherDiscardAnnouncement.SetDetailValues(
+						mlogFetcherDiscardAnnouncement.AssignDetails(
 							notification.origin,
 							notification.number,
 							notification.hash.Str(),
 							dist,
-						))
+						).Send(mlogFetcher)
 					}
 					glog.V(logger.Debug).Infof("[eth/62] Peer %s: discarded announcement #%d [%s], distance %d", notification.origin, notification.number, notification.hash.Hex(), dist)
 					metrics.FetchAnnounceDrops.Mark(1)
@@ -636,12 +636,12 @@ func (f *Fetcher) enqueue(peer string, block *types.Block) {
 	}
 	if dist := int64(block.NumberU64()) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
 		if logger.MlogEnabled() {
-			mlogFetcher.Send(mlogFetcherDiscardAnnouncement.SetDetailValues(
+			mlogFetcherDiscardAnnouncement.AssignDetails(
 				peer,
 				block.NumberU64(),
 				hash.Str(),
 				dist,
-			))
+			).Send(mlogFetcher)
 		}
 		glog.V(logger.Debug).Infof("Peer %s: discarded block #%d [%s], distance %d", peer, block.NumberU64(), hash.Hex(), dist)
 		metrics.FetchBroadcastDrops.Mark(1)

--- a/eth/fetcher/mlog.go
+++ b/eth/fetcher/mlog.go
@@ -5,10 +5,10 @@ import "github.com/ethereumproject/go-ethereum/logger"
 var mlogFetcher = logger.MLogRegisterAvailable("fetcher", mLogLines)
 
 var mLogLines = []logger.MLogT{
-	mlogFetcherDiscardAnnouncement,
+	*mlogFetcherDiscardAnnouncement,
 }
 
-var mlogFetcherDiscardAnnouncement = logger.MLogT{
+var mlogFetcherDiscardAnnouncement = &logger.MLogT{
 	Description: "Called when a block announcement is discarded.",
 	Receiver:    "FETCHER",
 	Verb:        "DISCARD",

--- a/logger/mlog_file.go
+++ b/logger/mlog_file.go
@@ -337,6 +337,8 @@ func (m *MLogT) FormatJSON() []byte {
 }
 
 func (m *MLogT) FormatKV() (out string) {
+	m.Lock()
+	defer m.Unlock()
 	m.placeholderize()
 	out = fmt.Sprintf("%s %s %s", m.Receiver, m.Verb, m.Subject)
 	for _, d := range m.Details {
@@ -351,6 +353,8 @@ func (m *MLogT) FormatKV() (out string) {
 }
 
 func (m *MLogT) FormatPlain() (out string) {
+	m.Lock()
+	defer m.Unlock()
 	m.placeholderize()
 	out = fmt.Sprintf("%s %s %s", m.Receiver, m.Verb, m.Subject)
 	for _, d := range m.Details {

--- a/logger/mlog_file.go
+++ b/logger/mlog_file.go
@@ -94,6 +94,7 @@ func (f mlogFormatT) String() string {
 
 // MLogT defines an mlog LINE
 type MLogT struct {
+	sync.Mutex
 	Description string        `json:"-"`
 	Receiver    string        `json:"receiver"`
 	Verb        string        `json:"verb"`
@@ -184,8 +185,17 @@ func MLogRegisterActive(component mlogComponent) {
 	mlogRegLock.Unlock()
 }
 
+//// SendMLog writes enabled component mlogs to file if the component is registered active.
+//func (c mlogComponent) Send(msg MLogT) {
+//	mlogRegLock.RLock()
+//	if l, exists := MLogRegistryActive[c]; exists {
+//		l.SendFormatted(GetMLogFormat(), 1, msg)
+//	}
+//	mlogRegLock.RUnlock()
+//}
+
 // SendMLog writes enabled component mlogs to file if the component is registered active.
-func (c mlogComponent) Send(msg MLogT) {
+func (msg *MLogT) Send(c mlogComponent) {
 	mlogRegLock.RLock()
 	if l, exists := MLogRegistryActive[c]; exists {
 		l.SendFormatted(GetMLogFormat(), 1, msg)
@@ -193,7 +203,8 @@ func (c mlogComponent) Send(msg MLogT) {
 	mlogRegLock.RUnlock()
 }
 
-func (l *Logger) SendFormatted(format mlogFormatT, level LogLevel, msg MLogT) {
+func (l *Logger) SendFormatted(format mlogFormatT, level LogLevel, msg *MLogT) {
+
 	switch format {
 	case mLOGKV:
 		l.Sendln(level, msg.FormatKV())
@@ -354,6 +365,8 @@ func (m *MLogT) FormatPlain() (out string) {
 }
 
 func (m *MLogT) MarshalJSON() ([]byte, error) {
+	m.Lock()
+	defer m.Unlock()
 	var obj = make(map[string]interface{})
 	obj["event"] = m.EventName()
 	obj["ts"] = time.Now()
@@ -485,22 +498,23 @@ func (m *MLogDetailT) AsDocumentation() *MLogDetailT {
 	return m
 }
 
-// SetDetailValues is a setter function for setting values for pre-existing details.
+// AssignDetails is a setter function for setting values for pre-existing details.
 // It accepts a variadic number of empty interfaces.
 // If the number of arguments does not match  the number of established details
 // for the receiving MLogT, it will fatal error.
 // Arguments MUST be provided in the order in which they should be applied to the
 // slice of existing details.
-func (m MLogT) SetDetailValues(detailVals ...interface{}) MLogT {
-
+func (m *MLogT) AssignDetails(detailVals ...interface{}) *MLogT {
 	// Check for congruence between argument length and registered details.
 	if len(detailVals) != len(m.Details) {
-		glog.Fatal("mlog: wrong number of details set, want: ", len(m.Details), "got:", len(detailVals))
+		glog.Fatal(m.EventName(), "wrong number of details set, want: ", len(m.Details), "got:", len(detailVals))
 	}
 
+	m.Lock()
 	for i, detailval := range detailVals {
 		m.Details[i].Value = detailval
 	}
+	defer m.Unlock()
 
 	return m
 }

--- a/logger/mlog_file_test.go
+++ b/logger/mlog_file_test.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"testing"
+)
+
+// mlogNeighborsHandleFrom is called once for each neighbors request from a node FROM
+var mlogExampleT = &MLogT{
+	Description: `Struct for testing mlog structs.`,
+	Receiver:    "TESTER",
+	Verb:        "TESTING",
+	Subject:     "MLOG",
+	Details: []MLogDetailT{
+		{"FROM", "UDP_ADDRESS", "STRING"},
+		{"FROM", "ID", "STRING"},
+		{"NEIGHBORS", "BYTES_TRANSFERRED", "INT"},
+	},
+}
+
+func BenchmarkSetDetailValues(b *testing.B) {
+	vals := []interface{}{"hello", "kitty", 42}
+	for i := 0; i < b.N; i++ {
+		mlogExampleT.AssignDetails(vals...)
+	}
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -125,10 +125,10 @@ func (self *Miner) Start(coinbase common.Address, threads int) {
 		self.worker.register(NewCpuAgent(i, self.pow))
 	}
 
-	mlogMiner.Send(mlogMinerStart.SetDetailValues(
+	mlogMinerStart.AssignDetails(
 		coinbase.Hex(),
 		threads,
-	))
+	).Send(mlogMiner)
 	glog.V(logger.Info).Infof("Starting mining operation (CPU=%d TOT=%d)\n", threads, len(self.worker.agents))
 
 	self.worker.start()
@@ -141,10 +141,10 @@ func (self *Miner) Stop() {
 	atomic.StoreInt32(&self.mining, 0)
 	atomic.StoreInt32(&self.shouldStart, 0)
 	if logger.MlogEnabled() {
-		mlogMiner.Send(mlogMinerStop.SetDetailValues(
+		mlogMinerStop.AssignDetails(
 			self.coinbase.Hex(),
 			self.threads,
-		))
+		).Send(mlogMiner)
 	}
 }
 

--- a/miner/mlog.go
+++ b/miner/mlog.go
@@ -5,16 +5,16 @@ import "github.com/ethereumproject/go-ethereum/logger"
 var mlogMiner = logger.MLogRegisterAvailable("miner", mlogMinerLines)
 
 var mlogMinerLines = []logger.MLogT{
-	mlogMinerStart,
-	mlogMinerStop,
-	mlogMinerCommitWorkBlock,
-	mlogMinerCommitUncle,
-	mlogMinerCommitTx,
-	mlogMinerMineBlock,
-	mlogMinerConfirmMinedBlock,
+	*mlogMinerStart,
+	*mlogMinerStop,
+	*mlogMinerCommitWorkBlock,
+	*mlogMinerCommitUncle,
+	*mlogMinerCommitTx,
+	*mlogMinerMineBlock,
+	*mlogMinerConfirmMinedBlock,
 }
 
-var mlogMinerStart = logger.MLogT{
+var mlogMinerStart = &logger.MLogT{
 	Description: `Called once when the miner starts.`,
 	Receiver:    "MINER",
 	Verb:        "START",
@@ -25,7 +25,7 @@ var mlogMinerStart = logger.MLogT{
 	},
 }
 
-var mlogMinerStop = logger.MLogT{
+var mlogMinerStop = &logger.MLogT{
 	Description: `Called once when the miner stops.`,
 	Receiver:    "MINER",
 	Verb:        "STOP",
@@ -36,7 +36,7 @@ var mlogMinerStop = logger.MLogT{
 	},
 }
 
-var mlogMinerCommitWorkBlock = logger.MLogT{
+var mlogMinerCommitWorkBlock = &logger.MLogT{
 	Description: `Called when the miner commits new work on a block.`,
 	Receiver:    "MINER",
 	Verb:        "COMMIT_WORK",
@@ -49,7 +49,7 @@ var mlogMinerCommitWorkBlock = logger.MLogT{
 	},
 }
 
-var mlogMinerCommitUncle = logger.MLogT{
+var mlogMinerCommitUncle = &logger.MLogT{
 	Description: `Called when the miner commits an uncle.
 If $COMMIT_UNCLE is non-nil, uncle is not committed.`,
 	Receiver: "MINER",
@@ -62,7 +62,7 @@ If $COMMIT_UNCLE is non-nil, uncle is not committed.`,
 	},
 }
 
-var mlogMinerCommitTx = logger.MLogT{
+var mlogMinerCommitTx = &logger.MLogT{
 	Description: `Called when the miner commits (or attempts to commit) a transaction.
 If $COMMIT.ERROR is non-nil, the transaction is not committed.`,
 	Receiver: "MINER",
@@ -75,7 +75,7 @@ If $COMMIT.ERROR is non-nil, the transaction is not committed.`,
 	},
 }
 
-var mlogMinerMineBlock = logger.MLogT{
+var mlogMinerMineBlock = &logger.MLogT{
 	Description: `Called when the miner has mined a block.
 $BLOCK.STATUS will be either 'stale' or 'wait_confirm'. $BLOCK.WAIT_CONFIRM is an integer
 specifying _n_ blocks to wait for confirmation based on block depth, relevant only for when $BLOCK.STATUS is 'wait_confirm'.`,
@@ -90,7 +90,7 @@ specifying _n_ blocks to wait for confirmation based on block depth, relevant on
 	},
 }
 
-var mlogMinerConfirmMinedBlock = logger.MLogT{
+var mlogMinerConfirmMinedBlock = &logger.MLogT{
 	Description: `Called once to confirm the miner has mined a block _n_ blocks back,
 where _n_ refers to the $BLOCK.WAIT_CONFIRM value from MINER MINE BLOCK.
 This is only a logging confirmation message, and is not related to work done.`,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -333,12 +333,12 @@ func (self *worker) wait() {
 				work.localMinedBlocks = newLocalMinedBlock(block.Number().Uint64(), work.localMinedBlocks)
 			}
 			if logger.MlogEnabled() {
-				mlogMiner.Send(mlogMinerMineBlock.SetDetailValues(
+				mlogMinerMineBlock.AssignDetails(
 					block.Number(),
 					block.Hash().Hex(),
 					staleOrConfirmMsg,
 					miningLogAtDepth,
-				))
+				).Send(mlogMiner)
 			}
 			glog.V(logger.Info).Infof("🔨  Mined %sblock (#%v / %x). %s", stale, block.Number(), block.Hash().Bytes()[:4], confirm)
 
@@ -438,9 +438,9 @@ func (self *worker) logLocalMinedBlocks(current, previous *Work) {
 			inspectBlockNum := checkBlockNum - miningLogAtDepth
 			if self.isBlockLocallyMined(current, inspectBlockNum) {
 				if logger.MlogEnabled() {
-					mlogMiner.Send(mlogMinerConfirmMinedBlock.SetDetailValues(
+					mlogMinerConfirmMinedBlock.AssignDetails(
 						inspectBlockNum,
-					))
+					).Send(mlogMiner)
 				}
 				glog.V(logger.Info).Infof("🔨 🔗  Mined %d blocks back: block #%v", miningLogAtDepth, inspectBlockNum)
 			}
@@ -566,12 +566,12 @@ func (self *worker) commitNewWork() {
 	if atomic.LoadInt32(&self.mining) == 1 {
 		elapsed := time.Since(tstart)
 		if logger.MlogEnabled() {
-			mlogMiner.Send(mlogMinerCommitWorkBlock.SetDetailValues(
+			mlogMinerCommitWorkBlock.AssignDetails(
 				work.Block.Number(),
 				work.tcount,
 				len(uncles),
 				elapsed,
-			))
+			).Send(mlogMiner)
 		}
 		glog.V(logger.Info).Infof("commit new work on block %v with %d txs & %d uncles. Took %v\n", work.Block.Number(), work.tcount, len(uncles), elapsed)
 		self.logLocalMinedBlocks(work, previous)
@@ -584,11 +584,11 @@ func (self *worker) commitUncle(work *Work, uncle *types.Header) error {
 	var e error
 	if logger.MlogEnabled() {
 		defer func() {
-			mlogMiner.Send(mlogMinerCommitUncle.SetDetailValues(
+			mlogMinerCommitUncle.AssignDetails(
 				uncle.Number,
 				hash.Hex(),
 				e,
-			))
+			).Send(mlogMiner)
 		}()
 	}
 	if work.uncles.Has(hash) {
@@ -696,11 +696,11 @@ func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, g
 
 	if logger.MlogEnabled() {
 		defer func() {
-			mlogMiner.Send(mlogMinerCommitTx.SetDetailValues(
+			mlogMinerCommitTx.AssignDetails(
 				env.header.Number,
 				tx.Hash().Hex(),
 				err,
-			))
+			).Send(mlogMiner)
 		}()
 	}
 

--- a/p2p/discover/mlog.go
+++ b/p2p/discover/mlog.go
@@ -16,7 +16,7 @@
 
 // This file 'mlog' is home to the 'discover' package implementation of mlog.
 // All available mlog lines should be established here as variables and documented.
-// For each instance of an mlog call, the respective MLogT variable SetDetailValues()
+// For each instance of an mlog call, the respective MLogT variable AssignDetails()
 // method should be called with per-use instance details.
 
 package discover
@@ -31,21 +31,21 @@ var mlogDiscover = logger.MLogRegisterAvailable("discover", mLogLines)
 // May be used for automatic mlog docmentation generator, or
 // for API usage/display/documentation otherwise.
 var mLogLines = []logger.MLogT{
-	mlogPingHandleFrom,
-	mlogPingSendTo,
-	mlogPongHandleFrom,
-	mlogPongSendTo,
-	mlogFindNodeHandleFrom,
-	mlogFindNodeSendTo,
-	mlogNeighborsHandleFrom,
-	mlogNeighborsSendTo,
+	*mlogPingHandleFrom,
+	*mlogPingSendTo,
+	*mlogPongHandleFrom,
+	*mlogPongSendTo,
+	*mlogFindNodeHandleFrom,
+	*mlogFindNodeSendTo,
+	*mlogNeighborsHandleFrom,
+	*mlogNeighborsSendTo,
 }
 
 // Collect and document available mlog lines.
 
 // PING
 // mlogPingHandleFrom is called once for each ping request from a node FROM
-var mlogPingHandleFrom = logger.MLogT{
+var mlogPingHandleFrom = &logger.MLogT{
 	Description: "Called once for each received PING request from peer FROM.",
 	Receiver:    "PING",
 	Verb:        "HANDLE",
@@ -57,7 +57,7 @@ var mlogPingHandleFrom = logger.MLogT{
 	},
 }
 
-var mlogPingSendTo = logger.MLogT{
+var mlogPingSendTo = &logger.MLogT{
 	Description: "Called once for each outgoing PING request to peer TO.",
 	Receiver:    "PING",
 	Verb:        "SEND",
@@ -70,7 +70,7 @@ var mlogPingSendTo = logger.MLogT{
 
 // PONG
 // mlogPongHandleFrom is called once for each pong request from a node FROM
-var mlogPongHandleFrom = logger.MLogT{
+var mlogPongHandleFrom = &logger.MLogT{
 	Description: "Called once for each received PONG request from peer FROM.",
 	Receiver:    "PONG",
 	Verb:        "HANDLE",
@@ -83,7 +83,7 @@ var mlogPongHandleFrom = logger.MLogT{
 }
 
 // mlogPingHandleFrom is called once for each ping request from a node FROM
-var mlogPongSendTo = logger.MLogT{
+var mlogPongSendTo = &logger.MLogT{
 	Description: "Called once for each outgoing PONG request to peer TO.",
 	Receiver:    "PONG",
 	Verb:        "SEND",
@@ -96,7 +96,7 @@ var mlogPongSendTo = logger.MLogT{
 
 // FINDNODE
 // mlogFindNodeHandleFrom is called once for each findnode request from a node FROM
-var mlogFindNodeHandleFrom = logger.MLogT{
+var mlogFindNodeHandleFrom = &logger.MLogT{
 	Description: "Called once for each received FIND_NODE request from peer FROM.",
 	Receiver:    "FINDNODE",
 	Verb:        "HANDLE",
@@ -109,7 +109,7 @@ var mlogFindNodeHandleFrom = logger.MLogT{
 }
 
 // mlogFindNodeHandleFrom is called once for each findnode request from a node FROM
-var mlogFindNodeSendTo = logger.MLogT{
+var mlogFindNodeSendTo = &logger.MLogT{
 	Description: "Called once for each received FIND_NODE request from peer FROM.",
 	Receiver:    "FINDNODE",
 	Verb:        "SEND",
@@ -122,7 +122,7 @@ var mlogFindNodeSendTo = logger.MLogT{
 
 // NEIGHBORS
 // mlogNeighborsHandleFrom is called once for each neighbors request from a node FROM
-var mlogNeighborsHandleFrom = logger.MLogT{
+var mlogNeighborsHandleFrom = &logger.MLogT{
 	Description: `Called once for each received NEIGHBORS request from peer FROM.`,
 	Receiver:    "NEIGHBORS",
 	Verb:        "HANDLE",
@@ -135,7 +135,7 @@ var mlogNeighborsHandleFrom = logger.MLogT{
 }
 
 // mlogFindNodeSendNeighbors is called once for each sent NEIGHBORS request
-var mlogNeighborsSendTo = logger.MLogT{
+var mlogNeighborsSendTo = &logger.MLogT{
 	Description: `Called once for each outgoing NEIGHBORS request to peer TO.`,
 	Receiver:    "NEIGHBORS",
 	Verb:        "SEND",

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -509,25 +509,25 @@ func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req interface{}) error {
 		switch ptype {
 		// @sorpass: again, performance penalty?
 		case pingPacket:
-			mlogDiscover.Send(mlogPingSendTo.SetDetailValues(
+			mlogPingSendTo.AssignDetails(
 				toaddr.String(),
 				len(packet),
-			))
+			).Send(mlogDiscover)
 		case pongPacket:
-			mlogDiscover.Send(mlogPongSendTo.SetDetailValues(
+			mlogPongSendTo.AssignDetails(
 				toaddr.String(),
 				len(packet),
-			))
+			).Send(mlogDiscover)
 		case findnodePacket:
-			mlogDiscover.Send(mlogFindNodeSendTo.SetDetailValues(
+			mlogFindNodeSendTo.AssignDetails(
 				toaddr.String(),
 				len(packet),
-			))
+			).Send(mlogDiscover)
 		case neighborsPacket:
-			mlogDiscover.Send(mlogNeighborsSendTo.SetDetailValues(
+			mlogNeighborsSendTo.AssignDetails(
 				toaddr.String(),
 				len(packet),
-			))
+			).Send(mlogDiscover)
 		}
 	}
 	if glog.V(logger.Detail) {
@@ -606,29 +606,29 @@ func (t *udp) handlePacket(from *net.UDPAddr, buf []byte) error {
 		// since packet is an interface with 1 method: handle.
 		switch p := fmt.Sprintf("%T", packet); p {
 		case "*discover.ping":
-			mlogDiscover.Send(mlogPingHandleFrom.SetDetailValues(
+			mlogPingHandleFrom.AssignDetails(
 				from.String(),
 				fromID.String(),
 				len(buf),
-			))
+			).Send(mlogDiscover)
 		case "*discover.pong":
-			mlogDiscover.Send(mlogPongHandleFrom.SetDetailValues(
+			mlogPongHandleFrom.AssignDetails(
 				from.String(),
 				fromID.String(),
 				len(buf),
-			))
+			).Send(mlogDiscover)
 		case "*discover.findnode":
-			mlogDiscover.Send(mlogFindNodeHandleFrom.SetDetailValues(
+			mlogFindNodeHandleFrom.AssignDetails(
 				from.String(),
 				fromID.String(),
 				len(buf),
-			))
+			).Send(mlogDiscover)
 		case "*discover.neighbors":
-			mlogDiscover.Send(mlogNeighborsHandleFrom.SetDetailValues(
+			mlogNeighborsHandleFrom.AssignDetails(
 				from.String(),
 				fromID.String(),
 				len(buf),
-			))
+			).Send(mlogDiscover)
 		}
 	}
 	if glog.V(logger.Detail) {

--- a/p2p/mlog.go
+++ b/p2p/mlog.go
@@ -5,11 +5,11 @@ import "github.com/ethereumproject/go-ethereum/logger"
 var mlogServer = logger.MLogRegisterAvailable("server", mLogLines)
 
 var mLogLines = []logger.MLogT{
-	mlogServerPeerAdded,
-	mlogServerPeerRemove,
+	*mlogServerPeerAdded,
+	*mlogServerPeerRemove,
 }
 
-var mlogServerPeerAdded = logger.MLogT{
+var mlogServerPeerAdded = &logger.MLogT{
 	Description: "Called once when a peer is added.",
 	Receiver:    "SERVER",
 	Verb:        "ADD",
@@ -22,7 +22,7 @@ var mlogServerPeerAdded = logger.MLogT{
 	},
 }
 
-var mlogServerPeerRemove = logger.MLogT{
+var mlogServerPeerRemove = &logger.MLogT{
 	Description: "Called once when a peer is removed.",
 	Receiver:    "SERVER",
 	Verb:        "REMOVE",

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -671,12 +671,12 @@ func (srv *Server) checkpoint(c *conn, stage chan<- *conn) error {
 // the peer.
 func (srv *Server) runPeer(p *Peer) {
 	if logger.MlogEnabled() {
-		mlogServer.Send(mlogServerPeerAdded.SetDetailValues(
+		mlogServerPeerAdded.AssignDetails(
 			srv.PeerCount(),
 			p.ID().String(),
 			p.RemoteAddr().String(),
 			p.Name(),
-		))
+		).Send(mlogServer)
 	}
 
 	glog.V(logger.Debug).Infof("Added %v\n", p)
@@ -696,11 +696,11 @@ func (srv *Server) runPeer(p *Peer) {
 	srv.delpeer <- p
 
 	if logger.MlogEnabled() {
-		mlogServer.Send(mlogServerPeerRemove.SetDetailValues(
+		mlogServerPeerRemove.AssignDetails(
 			srv.PeerCount(),
 			p.ID().String(),
 			discreason.String(),
-		))
+		).Send(mlogServer)
 	}
 
 	glog.V(logger.Debug).Infof("Removed %v (%v)\n", p, discreason)


### PR DESCRIPTION
solution: use pointers and mutex to ensure thread safety
for mlog value assignment

- use pointers for mlog line variables, eg. https://github.com/ethereumproject/go-ethereum/compare/master...fix/mlog-data-race3#diff-4dc7e76f731fe38a8e3002a0cd268922R65
- `MLogT` structs implements `sync.Mutex` https://github.com/ethereumproject/go-ethereum/compare/master...fix/mlog-data-race3#diff-ba08169fc9e92e28b2151b09a062521bR97
- rename `mlogT.SetDetailValues` -> `AsssignDetails`
- `AssignDetails` locks around value assignment https://github.com/ethereumproject/go-ethereum/compare/master...fix/mlog-data-race3#diff-ba08169fc9e92e28b2151b09a062521bR513, and locks around formatting, eg. https://github.com/ethereumproject/go-ethereum/compare/master...fix/mlog-data-race3#diff-ba08169fc9e92e28b2151b09a062521bR368
