### PR TITLE
allow custom chain config chainID value to be more flexible

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -371,6 +371,47 @@ func TestChainConfig_GetChainID(t *testing.T) {
 	}
 }
 
+// Test nonconventional settings.
+func TestChainConfig_GetChainID2(t *testing.T) {
+	// Test default hardcoded configs.
+	if DefaultConfigMainnet.ChainConfig.GetChainID().Cmp(DefaultConfigMainnet.ChainConfig.GetChainID()) != 0 {
+		t.Errorf("got: %v, want: %v", DefaultConfigMainnet.ChainConfig.GetChainID(), DefaultConfigMainnet.ChainConfig.GetChainID())
+	}
+	if DefaultConfigMorden.ChainConfig.GetChainID().Cmp(DefaultConfigMorden.ChainConfig.GetChainID()) != 0 {
+		t.Errorf("got: %v, want: %v", DefaultConfigMorden.ChainConfig.GetChainID(), DefaultConfigMorden.ChainConfig.GetChainID())
+	}
+
+	cc := DefaultConfigMainnet.ChainConfig
+	feat, fork, ok := cc.HasFeature("eip155")
+	if !ok {
+		t.Fatal("unexpected missing eip155 feature for default mainnet config")
+	}
+
+	var featI int
+	for i, f := range fork.Features {
+		if f == feat {
+			featI = i
+			break
+		}
+	}
+
+	fork.Features = append(fork.Features[:featI], fork.Features[featI+1:]...)
+	if _, _, ok := cc.HasFeature("eip155"); ok {
+		t.Fatal("unexpect existing eip155 feature; should have been removed for testing")
+	}
+
+	if cid := cc.GetChainID(); cid.Cmp(new(big.Int)) != 0 {
+		t.Errorf("want: 0, got: %v", cid)
+	}
+
+	dc := DefaultConfigMainnet
+	dc.ChainConfig = cc
+	if s, ok := dc.IsValid(); !ok {
+		t.Fatalf("want: valid; got: %v", s)
+	}
+}
+
+
 // Acceptance-y tests.
 
 // Test GetFeature gets expected feature values from default configuration data...

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -154,7 +154,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	}
 
 	glog.V(logger.Info).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", ProtocolVersions, config.NetworkId, config.ChainConfig.GetChainID())
-	glog.D(logger.Warn).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", logger.ColorGreen(fmt.Sprintf("%v", ProtocolVersions)), logger.ColorGreen(strconv.Itoa(config.NetworkId)), logger.ColorGreen(config.ChainConfig.GetChainID().String()))
+	glog.D(logger.Warn).Infof("Protocol Versions: %v, Network Id: %v, Chain Id: %v", logger.ColorGreen(fmt.Sprintf("%v", ProtocolVersions)), logger.ColorGreen(strconv.Itoa(config.NetworkId)), logger.ColorGreen(func() string { cid := config.ChainConfig.GetChainID().String(); if cid == "0" { cid = "not set" }; return cid }()))
 
 	// Load up any custom genesis block if requested
 	if config.Genesis != nil {


### PR DESCRIPTION
problem: `chainID` currently must be set on "Diehard" fork, and may not be omitted in the case of a custom chain.

solution: allow eip155/chainID chain config val to be set
on any fork, or not at all for custom configurations.

resolves #471