### PR TITLE
log mode not locked, should not panic if default

### DIFF
--- a/cmd/geth/log_dispatch.go
+++ b/cmd/geth/log_dispatch.go
@@ -21,6 +21,7 @@ var availableLogStatusFeatures = map[string]time.Duration{
 	"sync": time.Duration(0),
 }
 
+// lsMode represents the current behavior of the client.
 type lsMode uint
 
 const (

--- a/cmd/geth/log_display_basic.go
+++ b/cmd/geth/log_display_basic.go
@@ -252,6 +252,8 @@ var PrintStatusBasic = func(e *eth.Ethereum, tickerInterval time.Duration, inser
 		progressRateD.value = fmt.Sprintf(strScanLenOf(xprogressRateD, false), formatProgressRateD(-1, txs, mgas))
 		progressRateUnitsD.value = fmt.Sprintf(strScanLenOf(xprogressRateUnitsD, true), "txs/mgas")
 	default:
+		// This will be reached only when currentMode changes during the execution of the previous ~40 lines, which is very rarely.
+		// There is no harm done in this (default) case except having run a few unnecessary operations.
 	}
 	return current
 }

--- a/cmd/geth/log_display_basic.go
+++ b/cmd/geth/log_display_basic.go
@@ -252,7 +252,6 @@ var PrintStatusBasic = func(e *eth.Ethereum, tickerInterval time.Duration, inser
 		progressRateD.value = fmt.Sprintf(strScanLenOf(xprogressRateD, false), formatProgressRateD(-1, txs, mgas))
 		progressRateUnitsD.value = fmt.Sprintf(strScanLenOf(xprogressRateUnitsD, true), "txs/mgas")
 	default:
-		panic("unreachable")
 	}
 	return current
 }

--- a/cmd/geth/log_display_util.go
+++ b/cmd/geth/log_display_util.go
@@ -28,7 +28,8 @@ func (e logEventType) String() string {
 
 // Global bookmark vars.
 // These are accessible globally to allow inter-communication between display system event handlers.
-// TODO: ensure handler cooperation; ie use a mutex, atomic, or something
+// Note: since these may be read/modified from concurrent operations (eg. handler fns), these variables are NOT thread safe.
+// In the case that a logging operation requires thread safety, use externally implemented locking.
 var currentMode = lsModeDiscover
 var currentBlockNumber uint64
 var chainEventLastSent time.Time


### PR DESCRIPTION
`lsMode` is not guaranteed to be thread safe. If functions want to assure this, they can use a lock or assign a separate variable.

```
2018-01-29 01:51:18 Fast #1591550 of #5290128 30.09% 253/63 blk/mgas sec 6/25 peers
2018-01-29 01:56:09 Discover 5/25 peers
panic: unreachable
goroutine 119 [running]:
main.glob..func5(0xc421410fc0, 0xdf8475800, 0x0, 0x19, 0x0)
/home/travis/gopath/src/github.com/ethereumproject/go-ethereum/cmd/geth/log_display_basic.go:255 +0x1174
main.glob..func4(0xc4200d5cc0, 0xc421410fc0, 0x0, 0x0, 0xdf8475800)
/home/travis/gopath/src/github.com/ethereumproject/go-ethereum/cmd/geth/log_display_basic.go:89 +0xaf
main.(*displayEventHandlers).runAllIfAny(0xc42068e180, 0xc4200d5cc0, 0xc421410fc0, 0x0, 0x0, 0xdf8475800, 0x7)
/home/travis/gopath/src/github.com/ethereumproject/go-ethereum/cmd/geth/log_dispatch.go:93 +0xb7
main.runDisplayLogs.func3(0xc420566880, 0xc4200d5cc0, 0xc421410fc0, 0xdf8475800, 0xc42068e180)
/home/travis/gopath/src/github.com/ethereumproject/go-ethereum/cmd/geth/log_dispatch.go:222 +0xb3
created by main.runDisplayLogs
/home/travis/gopath/src/github.com/ethereumproject/go-ethereum/cmd/geth/log_dispatch.go:217 +0x55c
```