### PR TITLE
Added chain configuration and p2p rates/totals to dash display

### DIFF
--- a/cmd/geth/log_display_dash.go
+++ b/cmd/geth/log_display_dash.go
@@ -58,6 +58,8 @@ import (
 )
 
 const (
+	tuiHeaderHeight = 2
+	tuiHeaderStart = 1
 	tuiSmallHeight = 3
 	tuiMediumHeight = 5
 	tuiLargeHeight = 8
@@ -99,22 +101,23 @@ func tuiDrawDash(e *eth.Ethereum) {
 		if cacheChainIdentity != "" {
 			cname = cacheChainIdentity
 		}
-		headerInfo.Text = fmt.Sprintf("Mode=%s Chain=%v(%d) Chain Id=%d \n" +
-			"local_head ◼ n=%d ⬡=%s txs=%d time=%v ago",
+		headerInfo.Text = fmt.Sprintf(" Mode=%s Chain=%v(%d) Chain Id=%d \n" +
+			" local_head ◼ n=%d ⬡=%s txs=%d time=%v ago",
 				currentMode, cname, cnet, cid, currentBlockNumber, cb.Hash().Hex()[:10] + "…", cb.Transactions().Len(),
 					time.Since(time.Unix(cb.Time().Int64(), 0)).Round(time.Second))
+		syncheightGauge.BorderLabel = fmt.Sprintf("Sync")
 
 	}
-	termui.Render(headerInfo, peerCountSparkHolder, peerList, blkMgasTxsSparkHolder)
+	termui.Render(headerInfo, syncheightGauge, peerCountSparkHolder, peerList, blkMgasTxsSparkHolder)
 }
 
 func tuiSetupDashComponents() {
 
 	/// Config Info Header
 	headerInfo = termui.NewPar("")
-	headerInfo.X = 2
-	headerInfo.Height = 2
+	headerInfo.Height = tuiHeaderHeight
 	headerInfo.Border = false
+	headerInfo.X = tuiHeaderStart
 	headerInfo.TextBgColor = termui.ColorWhite
 	headerInfo.TextFgColor = termui.ColorBlack
 	headerInfo.SetWidth(termui.TermWidth() - 1)
@@ -124,6 +127,7 @@ func tuiSetupDashComponents() {
 	syncheightGauge.BarColor = termui.ColorRed
 	syncheightGauge.Height = tuiSmallHeight
 	syncheightGauge.Width = tuiLargeWidth
+	syncheightGauge.Y = tuiHeaderHeight + 1
 	//// Mgas spark
 	mgasSpark = termui.Sparkline{}
 	mgasSpark.Title = "Mgas"

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -384,6 +384,7 @@ func (s *Ethereum) DappDb() ethdb.Database             { return s.dappDb }
 func (s *Ethereum) IsListening() bool                  { return true } // Always listening
 func (s *Ethereum) EthVersion() int                    { return int(s.protocolManager.SubProtocols[0].Version) }
 func (s *Ethereum) NetVersion() int                    { return s.netVersionId }
+func (s *Ethereum) ChainConfig() *core.ChainConfig     { return s.chainConfig }
 func (s *Ethereum) Downloader() *downloader.Downloader { return s.protocolManager.downloader }
 
 // Protocols implements node.Service, returning all the currently configured


### PR DESCRIPTION
Added chain name, id(morden or mainnet), chain id and p2p rx/tx rates/totals to the dash display.
I have attached screenshot for the same below.

<img width="709" alt="screen shot 2018-02-05 at 11 49 38 pm" src="https://user-images.githubusercontent.com/8496488/35821540-4b732d6e-0acf-11e8-95ae-9726c2529e3f.png">

Signed-off-by: Manush <manush@lavellenetworks.com>