### PR TITLE
CircleCI: specify go1.9.3, and only (brew) install if not cached

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
           command: |
             export GOPATH=$HOME/go
             export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
-            brew unlink go
-            brew install go
+	    # Install go 1.9.3
+	    export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && git -C "$BDIR" checkout master && unset BDIR
             brew install bats
             brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,10 @@ jobs:
           name: Install required software
           command: |
             export GOPATH=$HOME/go
-            export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
-            export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && brew switch go 1.9.3 && git -C "$BDIR" checkout master && unset BDIR
+            export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin]
+            brew update
+            export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" reset --hard master && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && brew switch go 1.9.3 && git -C "$BDIR" checkout master && unset BDIR
+            brew info go
             brew install bats
             brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,8 @@ jobs:
           command: |
             export GOPATH=$HOME/go
             export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
-            brew install -f go
+            brew unlink go
+            brew install go
             brew install bats
             brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ sputnik_vm_steps: &sputnik_vm_steps
           cd $GOPATH/src/github.com/ethereumproject/sputnikvm-ffi/c/ffi && cargo build --release
           cp $GOPATH/src/github.com/ethereumproject/sputnikvm-ffi/c/ffi/target/release/libsputnikvm_ffi.a $GOPATH/src/github.com/ethereumproject/sputnikvm-ffi/c/libsputnikvm.a
     - persist_to_workspace:
-        root: ~/ 
+        root: ~/
         paths:
           - go/src/github.com/ethereumproject/sputnikvm-ffi/c/libsputnikvm.a
 
@@ -100,8 +100,7 @@ jobs:
           command: |
             export GOPATH=$HOME/go
             export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
-	    # Install go 1.9.3
-	    export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && git -C "$BDIR" checkout master && unset BDIR
+            export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && brew switch go 1.9.3 && git -C "$BDIR" checkout master && unset BDIR
             brew install bats
             brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           command: |
             export GOPATH=$HOME/go
             export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
-            brew install go
+            brew install -f go
             brew install bats
             brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,14 +100,15 @@ jobs:
           command: |
             export GOPATH=$HOME/go
             export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin]
-            brew update
-            export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" reset --hard master && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && brew switch go 1.9.3 && git -C "$BDIR" checkout master && unset BDIR
-            brew info go
-            brew install bats
-            brew install gpg2
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
             if [ ! -x ~/janusbin/janus ]; then
               cd $HOME; curl -sL https://raw.githubusercontent.com/ethereumproject/janus/master/get.sh | bash
+              brew update
+              export BDIR="$(brew --repo homebrew/core)" && echo "$BDIR" && git -C "$BDIR" reset --hard master && git -C "$BDIR" fetch origin ac2308d7640e45de0de1dbcbb6d4f42fcdd8adde && git -C "$BDIR" checkout FETCH_HEAD && HOMEBREW_NO_AUTO_UPDATE=1 brew install go && brew switch go 1.9.3 && git -C "$BDIR" checkout master && unset BDIR
+              brew info go
+              go version
+              brew install bats
+              brew install gpg2
             fi
       - persist_to_workspace:
           root: ~/


### PR DESCRIPTION
### problem: CircleCI brew install go at go upgrade

```
==> Downloading https://homebrew.bintray.com/bottles/go-1.9.4.sierra.bottle.tar.gz

==> Pouring go-1.9.4.sierra.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/go
Target /usr/local/bin/go
is a symlink belonging to go. You can unlink it:
  brew unlink go

To force the link and overwrite all conflicting files:
  brew link --overwrite go

To list all files that would be deleted:
  brew link --overwrite --dry-run go

Possible conflicting files are:
/usr/local/bin/go -> /usr/local/Cellar/go/1.9.3/bin/go
/usr/local/bin/godoc -> /usr/local/Cellar/go/1.9.3/bin/godoc
/usr/local/bin/gofmt -> /usr/local/Cellar/go/1.9.3/bin/gofmt
==> Caveats
A valid GOPATH is required to use the `go get` command.
If $GOPATH is not specified, $HOME/go will be used by default:
  https://golang.org/doc/code.html#GOPATH

You may wish to add the GOROOT-based install location to your PATH:
  export PATH=$PATH:/usr/local/opt/go/libexec/bin
==> Summary
🍺  /usr/local/Cellar/go/1.9.4: 7,654 files, 294MB
```
> https://circleci.com/gh/ethereumproject/go-ethereum/241?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


### solution: 
```
brew unlink go
brew install go
```

__PTAL__: not sure this the best way to do it... alternatively maybe with `brew link -f go`? after? not sure. 
