### PR TITLE
problem: calling synchronise from handler more than necessary

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -653,7 +653,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			currentBlock := pm.blockchain.CurrentBlock()
 			if localTd := pm.blockchain.GetTd(currentBlock.Hash()); trueTD.Cmp(localTd) > 0 {
 				glog.V(logger.Info).Infof("Peer %s: localTD=%v (<) peerTrueTD=%v, synchronising", p.id, localTd, trueTD)
-				go pm.synchronise(p)
+				if !pm.downloader.Synchronising() {
+					go pm.synchronise(p)
+				}
 			} else {
 				glog.V(logger.Detail).Infof("Peer %s: localTD=%v (>=) peerTrueTD=%v, NOT synchronising", p.id, localTd, trueTD)
 			}


### PR DESCRIPTION
solution: check if downloader is available before

since the sync method is synchronous