### PR TITLE
remove appveyor artifact storage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,6 @@ build_script:
   - go test -tags=sputnikvm ./...
   - go build -tags=sputnikvm -ldflags "-X main.Version=%VERSION%" ./cmd/geth
   - 7z a geth-classic-win64-%VERSION%.zip geth.exe
-artifacts:
-  - path: '*.zip'
-    name: geth
 before_deploy:
   # Set up GCP upload.
   - nuget install secure-file -ExcludeVersion


### PR DESCRIPTION
### problem
Appveyor out of artifact storage, and impossible to delete any of the old artifacts.
```
ok  	github.com/ethereumproject/go-ethereum/rpc	1.116s
ok  	github.com/ethereumproject/go-ethereum/tests	20.755s
ok  	github.com/ethereumproject/go-ethereum/trie	0.953s
ok  	github.com/ethereumproject/go-ethereum/whisper	9.888s
go build -tags=sputnikvm -ldflags "-X main.Version=%VERSION%" ./cmd/geth
7z a geth-classic-win64-%VERSION%.zip geth.exe
7-Zip [64] 16.04 : Copyright (c) 1999-2016 Igor Pavlov : 2016-10-04
Scanning the drive:
1 file, 38813643 bytes (38 MiB)
Creating archive: geth-classic-win64-v4.2.2+8-393532e.zip
Items to compress: 1
Files read from disk: 1
Archive size: 11499864 bytes (11 MiB)
Everything is Ok
Discovering tests...OK
Collecting artifacts...
Found artifact 'geth-classic-win64-v4.2.2+8-393532e.zip' matching '*.zip' path
Uploading artifacts...
Maximum allowed artifact storage size of 10000 Mb will be exceeded.
```

eg. https://ci.appveyor.com/project/splix/go-ethereum/build/1.0.1476


### solution

Remove artifact storing from config.
