### PR TITLE
problem: mlog session id vals out of order in line

### DIFF
--- a/logger/mlog_file.go
+++ b/logger/mlog_file.go
@@ -370,7 +370,7 @@ func (m *MLogT) FormatKV() (out string) {
 	m.Lock()
 	defer m.Unlock()
 	m.placeholderize()
-	out = fmt.Sprintf("session=%s %s %s %s", common.SessionID, m.Receiver, m.Verb, m.Subject)
+	out = fmt.Sprintf("%s %s %s session=%s", m.Receiver, m.Verb, m.Subject, common.SessionID)
 	for _, d := range m.Details {
 		v := fmt.Sprintf("%v", d.Value)
 		// quote strings which contains spaces
@@ -386,7 +386,7 @@ func (m *MLogT) FormatPlain() (out string) {
 	m.Lock()
 	defer m.Unlock()
 	m.placeholderize()
-	out = fmt.Sprintf("%s %s %s %s", common.SessionID, m.Receiver, m.Verb, m.Subject)
+	out = fmt.Sprintf("%s %s %s %s", m.Receiver, m.Verb, m.Subject, common.SessionID)
 	for _, d := range m.Details {
 		v := fmt.Sprintf("%v", d.Value)
 		// quote strings which contains spaces


### PR DESCRIPTION
solution: reorder to keep descending priority/scope

See the `session` (`ksJR`) vals in Key Value and Plain for only changes

----

### Old

__Key value__:
```
2018/03/13 22:40:35 [miner] session=ksJR REMOTE_AGENT SUBMIT WORK work.nonce=$INT work.mix_digest=$STRING work.hash=$STRING work.exists=$BOOL
```

__JSON__:
```json
{"component":"miner","event":"remote_agent.submit.work","session":"ksJR","ts":"2018-03-13T22:40:35.211296749+09:00","work.exists":true,"work.hash":"string","work.mix_digest":"string","work.nonce":0}
```

__Plain__:
```
2018/03/13 22:40:35 [miner] ksJR REMOTE_AGENT SUBMIT WORK $INT $STRING $STRING $BOOL
```

----
⬇️ 
----

### New

__Key value__:
```
2018/03/13 22:40:35 [miner] REMOTE_AGENT SUBMIT WORK session=ksJR work.nonce=$INT work.mix_digest=$STRING work.hash=$STRING work.exists=$BOOL
```

__JSON__:
```json
{"component":"miner","event":"remote_agent.submit.work","session":"ksJR","ts":"2018-03-13T22:40:35.211296749+09:00","work.exists":true,"work.hash":"string","work.mix_digest":"string","work.nonce":0}
```

__Plain__:
```
2018/03/13 22:40:35 [miner] REMOTE_AGENT SUBMIT WORK ksJR $INT $STRING $STRING $BOOL
```
