### PR TITLE
fix mlog wire casting cases with error

### DIFF
--- a/eth/mlog.go
+++ b/eth/mlog.go
@@ -92,6 +92,11 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 					-1,
 				)
 			}
+		} else if err != nil {
+			details = append(details,
+				common.Hash{}.Hex(),
+				-1,
+			)
 		} else {
 			glog.Fatal("cant cast: NewBlockHashesMsg", direction)
 		}
@@ -107,6 +112,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireSendTxs
 			if payload, ok := data.(types.Transactions); ok {
 				l = payload.Len()
+			} else if err != nil {
+				l = 0
 			} else {
 				glog.Fatal("cant cast: TxMsg", direction)
 			}
@@ -114,6 +121,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireReceiveTxs
 			if payload, ok := data.([]*types.Transaction); ok {
 				l = len(payload)
+			} else if err != nil {
+				l = 0
 			} else {
 				glog.Fatal("cant cast: TxMsg", direction)
 			}
@@ -129,6 +138,14 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 				payload.Skip,
 				payload.Reverse,
 			}...)
+		} else if err != nil || payload == nil {
+			details = append(details,
+				common.Hash{}.Hex(),
+				0,
+				0,
+				0,
+				false,
+			)
 		} else {
 			glog.Fatal("cant cast: GetBlockHeadersMsg", direction)
 		}
@@ -154,6 +171,11 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 					-1,
 				)
 			}
+		} else if err != nil {
+			details = append(details,
+				common.Hash{}.Hex(),
+				-1,
+			)
 		} else {
 			glog.Fatal("cant cast: BlockHeadersMsg", direction)
 		}
@@ -173,6 +195,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 				} else {
 					details = append(details, common.Hash{}.Hex())
 				}
+			} else if err != nil {
+				details = append(details, common.Hash{}.Hex())
 			} else {
 				glog.Fatal("cant cast: GetBlockBodiesMsg", direction)
 			}
@@ -182,6 +206,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 				details = append(details,
 					len(payload),
 				)
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: GetBlockBodiesMsg", direction)
 			}
@@ -192,6 +218,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireSendBlockBodies
 			if payload, ok := data.([]rlp.RawValue); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: BlockBodiesMsg", direction)
 			}
@@ -199,6 +227,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireReceiveBlockBodies
 			if payload, ok := data.(blockBodiesData); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: BlockBodiesMsg", direction)
 			}
@@ -222,6 +252,12 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			} else {
 				details = append(details, 0)
 			}
+		} else if err != nil {
+			details = append(details,
+				common.Hash{}.Hex(),
+				-1,
+				0,
+			)
 		} else {
 			glog.Fatal("cant cast: NewBlockMsg", direction)
 		}
@@ -241,6 +277,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 				} else {
 					details = append(details, common.Hash{}.Hex())
 				}
+			} else if err != nil {
+				details = append(details, common.Hash{}.Hex())
 			} else {
 				glog.Fatal("cant cast: GetNodeDataMsg", direction)
 			}
@@ -248,6 +286,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireReceiveGetNodeData
 			if payload, ok := data.([][]byte); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: GetNodeDataMsg", direction)
 			}
@@ -256,6 +296,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 	case NodeDataMsg:
 		if payload, ok := data.([][]byte); ok {
 			details = append(details, len(payload))
+		} else if err != nil {
+			details = append(details, 0)
 		} else {
 			glog.Fatal("cant cast: GetNNodeDataMsg", direction)
 		}
@@ -275,6 +317,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 				} else {
 					details = append(details, common.Hash{}.Hex())
 				}
+			} else if err != nil {
+				details = append(details, common.Hash{}.Hex())
 			} else {
 				glog.Fatal("cant cast: GetReceiptsMsg", direction)
 			}
@@ -282,6 +326,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireReceiveGetReceipts
 			if payload, ok := data.([]rlp.RawValue); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: GetNNodGetReceiptsMsg", direction)
 			}
@@ -292,6 +338,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireSendReceipts
 			if payload, ok := data.([]rlp.RawValue); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: ReceiptsMsg", direction)
 			}
@@ -299,6 +347,8 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 			line = mlogWireReceiveReceipts
 			if payload, ok := data.([][]*types.Receipt); ok {
 				details = append(details, len(payload))
+			} else if err != nil {
+				details = append(details, 0)
 			} else {
 				glog.Fatal("cant cast: ReceiptsMsg", direction)
 			}

--- a/eth/mlog.go
+++ b/eth/mlog.go
@@ -49,10 +49,27 @@ func mlogWireDelegate(p *peer, direction string, msgCode uint64, size int, data 
 		msgCode,
 		size,
 		ProtocolMessageStringer(uint(msgCode)),
-		p.id,
-		p.RemoteAddr().String(),
-		p.version,
-		err,
+	}
+	if p != nil {
+		details = append(details,
+			p.id,
+			p.RemoteAddr().String(),
+			p.version,
+		)
+	} else {
+		// for testing
+		details = append(details,
+			0,
+			"123.123.123.123",
+			42,
+		)
+	}
+
+	// Use error string if err not nil
+	if err != nil {
+		details = append(details, err.Error())
+	} else {
+		details = append(details, err)
 	}
 
 	// This could obviously be refactored, but I like the explicitness of it.

--- a/eth/mlog_test.go
+++ b/eth/mlog_test.go
@@ -1,0 +1,43 @@
+package eth
+
+import (
+	"bytes"
+	"github.com/ethereumproject/go-ethereum/core/types"
+	"github.com/ethereumproject/go-ethereum/logger"
+	"strings"
+	"testing"
+)
+
+func TestMlogWireDelegateError(t *testing.T) {
+	logger.SetMlogEnabled(true)
+	logger.Reset()
+	// Set up a log sys with a local buffer instead of file
+	var b = new(bytes.Buffer)
+	sys := logger.NewMLogSystem(b, 0, logger.LogLevel(1), false)
+	logger.AddLogSystem(sys)
+
+	logger.MLogRegisterActive("wire")
+
+	// test with error
+	err := errResp(ErrMsgTooLarge, "%v > %v", 42, ProtocolMaxMsgSize)
+	mlogWireDelegate(nil, "receive", TxMsg, 42, "not castable to txs", err) // TODO: all msg codes
+
+	logger.Flush() // wait for messages to be delivered
+
+	if !strings.Contains(b.String(), errorToString[ErrMsgTooLarge]) {
+		t.Errorf("got: %v, want: %v", b.String(), errorToString[ErrMsgTooLarge])
+	}
+	b.Reset()
+
+	// test without error
+	err = nil
+	txs := []*types.Transaction{}                         // don't want to be nil
+	mlogWireDelegate(nil, "receive", TxMsg, 42, txs, err) // TODO: all msg codes
+
+	logger.Flush() // wait for messages to be delivered
+
+	if strings.Contains(b.String(), errorToString[ErrMsgTooLarge]) {
+		t.Errorf("got: %v, want: %v", errorToString[ErrMsgTooLarge], b.String())
+	}
+	b.Reset()
+}


### PR DESCRIPTION
fixes #541 

problem: mlog delegate is unable to cast a data value because it is invalid - _because_ there was an error in the wire protocol. 

solution: all mlog wire delegate should check for incoming errors before `fatal`ing on casting errors; if there's an incoming error it should not be guaranteed that data values are valid.