### PR TITLE
Feat/improve help documentation

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -178,7 +178,7 @@ geth account import <keyfile>
 				Usage:  "Build persistent account index",
 				Description: `
 
-geth --index-accounts account index
+geth account index
 
 	Create keystore directory index cache database (keystore/accounts.db),
 	which is relevant for use with large amounts of key files (>10,000).
@@ -197,7 +197,9 @@ geth --index-accounts account index
 func accountIndex(ctx *cli.Context) error {
 	n := aliasableName(AccountsIndexFlag.Name, ctx)
 	if !ctx.GlobalBool(n) {
-		log.Fatalf("Use: $ geth --%v account index\n (missing '%v' flag)", n, n)
+		if e := ctx.GlobalSet(n, "true"); e != nil {
+			log.Fatal("err set flag", e)
+		}
 	}
 	am := MakeAccountManager(ctx)
 	errs := am.BuildIndexDB()

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/ethereumproject/go-ethereum/common"
-	"github.com/ethereumproject/go-ethereum/console"
 	"github.com/ethereumproject/go-ethereum/core"
 	"github.com/ethereumproject/go-ethereum/core/state"
 	"github.com/ethereumproject/go-ethereum/core/types"
@@ -57,12 +56,6 @@ var (
 		Name:    "upgrade-db",
 		Aliases: []string{"upgradedb"},
 		Usage:   "Upgrade chainblock database",
-	}
-	removedbCommand = cli.Command{
-		Action:  removeDB,
-		Name:    "remove-db",
-		Aliases: []string{"removedb"},
-		Usage:   "Remove blockchain and state databases",
 	}
 	dumpCommand = cli.Command{
 		Action: dump,
@@ -105,7 +98,7 @@ var (
 	resetCommand = cli.Command{
 		Action: resetChaindata,
 		Name:   "reset",
-		Usage:  "Reset the chain database",
+		Usage:  "Reset (remove) the chain database",
 		Description: `
 		Reset does a hard reset of the entire chain database.
 		This is a drastic and irreversible command, and should be used with caution.
@@ -168,25 +161,6 @@ func exportChain(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Export done in %v", time.Since(start))
-	return nil
-}
-
-func removeDB(ctx *cli.Context) error {
-	confirm, err := console.Stdin.PromptConfirm("Remove local database?")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if confirm {
-		fmt.Println("Removing chaindata...")
-		start := time.Now()
-
-		os.RemoveAll(filepath.Join(ctx.GlobalString(DataDirFlag.Name), "chaindata"))
-
-		fmt.Printf("Removed in %v\n", time.Since(start))
-	} else {
-		fmt.Println("Operation aborted")
-	}
 	return nil
 }
 

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -228,8 +228,9 @@ var (
 		Value: DirectoryString{filepath.Join(common.DefaultDataDir(), "mainnet", "mlogs")},
 	}
 	MLogComponentsFlag = cli.StringFlag{
-		Name:  "mlog-components",
-		Usage: "Set machine-readable logging components, comma-separated. Use a '!'-prefix to disabled listed components instead.",
+		Name: "mlog-components",
+		Usage: `Set machine-readable logging components, comma-separated. 
+	Use a '!'-prefix to disabled listed components instead.`,
 		Value: "blockchain,txpool,downloader,fetcher,discover,server,state,headerchain,miner,client,wire",
 	}
 	BacktraceAtFlag = cli.GenericFlag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -119,7 +119,6 @@ func makeCLIApp() (app *cli.App) {
 		exportCommand,
 		dumpChainConfigCommand,
 		upgradedbCommand,
-		removedbCommand,
 		dumpCommand,
 		rollbackCommand,
 		recoverCommand,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -45,6 +45,67 @@ func init() {
 	common.SetClientVersion(Version)
 }
 
+var makeDagCommand = cli.Command{
+	Action:  makedag,
+	Name:    "make-dag",
+	Aliases: []string{"makedag"},
+	Usage:   "Generate ethash dag (for testing)",
+	Description: `
+		The makedag command generates an ethash DAG in /tmp/dag.
+	
+		This command exists to support the system testing project.
+		Regular users do not need to execute it.
+				`,
+}
+
+var gpuInfoCommand = cli.Command{
+	Action:  gpuinfo,
+	Name:    "gpu-info",
+	Aliases: []string{"gpuinfo"},
+	Usage:   "GPU info",
+	Description: `
+	Prints OpenCL device info for all found GPUs.
+			`,
+}
+
+var gpuBenchCommand = cli.Command{
+	Action:  gpubench,
+	Name:    "gpu-bench",
+	Aliases: []string{"gpubench"},
+	Usage:   "Benchmark GPU",
+	Description: `
+	Runs quick benchmark on first GPU found.
+			`,
+}
+
+var versionCommand = cli.Command{
+	Action: version,
+	Name:   "version",
+	Usage:  "Print ethereum version numbers",
+	Description: `
+	The output of this command is supposed to be machine-readable.
+			`,
+}
+
+var makeMlogDocCommand = cli.Command{
+	Action: makeMLogDocumentation,
+	Name:   "mdoc",
+	Usage:  "Generate mlog documentation",
+	Description: `
+	Auto-generates documentation for all available mlog lines.
+	Use -md switch to toggle markdown output (eg. for wiki).
+	Arguments may be used to specify exclusive candidate components;
+	so 'geth mdoc -md discover' will generate markdown documentation only
+	for the 'discover' component.
+			`,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "md",
+			Usage: "Toggle markdown formatting",
+		},
+	},
+}
+
 func makeCLIApp() (app *cli.App) {
 	app = cli.NewApp()
 	app.Name = filepath.Base(os.Args[0])
@@ -71,62 +132,11 @@ func makeCLIApp() (app *cli.App) {
 		javascriptCommand,
 		statusCommand,
 		apiCommand,
-		{
-			Action:  makedag,
-			Name:    "make-dag",
-			Aliases: []string{"makedag"},
-			Usage:   "Generate ethash dag (for testing)",
-			Description: `
-	The makedag command generates an ethash DAG in /tmp/dag.
-
-	This command exists to support the system testing project.
-	Regular users do not need to execute it.
-			`,
-		},
-		{
-			Action:  gpuinfo,
-			Name:    "gpu-info",
-			Aliases: []string{"gpuinfo"},
-			Usage:   "GPU info",
-			Description: `
-	Prints OpenCL device info for all found GPUs.
-			`,
-		},
-		{
-			Action:  gpubench,
-			Name:    "gpu-bench",
-			Aliases: []string{"gpubench"},
-			Usage:   "Benchmark GPU",
-			Description: `
-	Runs quick benchmark on first GPU found.
-			`,
-		},
-		{
-			Action: version,
-			Name:   "version",
-			Usage:  "Print ethereum version numbers",
-			Description: `
-	The output of this command is supposed to be machine-readable.
-			`,
-		},
-		{
-			Action: makeMLogDocumentation,
-			Name:   "mdoc",
-			Usage:  "Generate mlog documentation",
-			Description: `
-	Auto-generates documentation for all available mlog lines.
-	Use -md switch to toggle markdown output (eg. for wiki).
-	Arguments may be used to specify exclusive candidate components;
-	so 'geth mdoc -md discover' will generate markdown documentation only
-	for the 'discover' component.
-			`,
-			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "md",
-					Usage: "Toggle markdown formatting",
-				},
-			},
-		},
+		makeDagCommand,
+		gpuInfoCommand,
+		gpuBenchCommand,
+		versionCommand,
+		makeMlogDocCommand,
 	}
 
 	app.Flags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -25,35 +25,57 @@ import (
 )
 
 // AppHelpTemplate is the test template for the default, global app help topic.
+//var x = cli.Command{}
+//x.Usage
+//x.UsageText
+//x.ArgsUsage
+//x.Subcommands
 var AppHelpTemplate = `NAME:
    {{.App.Name}} - {{.App.Usage}}
 
 USAGE:
    {{.App.HelpName}} [options]{{if .App.Commands}} <command> [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}
+
 VERSION:
-   {{.App.Version}}{{if .App.Commands}}
-COMMANDS:
-   {{range .App.Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{end}}{{if .FlagGroups}}
-{{range .FlagGroups}}{{.Name}} OPTIONS:
-  {{range .Flags}}{{.}}
+   {{.App.Version}}{{if .CommandAndFlagGroups}}
+
+COMMANDS AND FLAGS:
+------------------------------------------------------------------------
+{{range .CommandAndFlagGroups}}{{.Name}}
+------------------------------------------------------------------------
+  {{if .Commands}}{{range .Commands}}
+    {{join .Names ", "}}{{ "\t" }}{{.Usage}}{{ if .Subcommands }}{{ "\n\n" }}{{end}}{{range .Subcommands}}{{"\t"}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}{{"\n"}}{{end}}{{end}}
+  
+  {{end}}{{range .Flags}}{{.}}
   {{end}}
 {{end}}{{end}}{{if .App.Copyright }}
+
 COPYRIGHT:
    {{.App.Copyright}}
    {{end}}
 `
 
-// flagGroup is a collection of flags belonging to a single topic.
+// flagGroup is a collection of commands and/or flags belonging to a single topic.
 type flagGroup struct {
-	Name  string
-	Flags []cli.Flag
+	Name     string
+	Flags    []cli.Flag
+	Commands []cli.Command
 }
 
-// AppHelpFlagGroups is the application flags, grouped by functionality.
-var AppHelpFlagGroups = []flagGroup{
+// AppHelpFlagAndCommandGroups is the application flags, grouped by functionality.
+var AppHelpFlagAndCommandGroups = []flagGroup{
 	{
 		Name: "ETHEREUM",
+		Commands: []cli.Command{
+			importCommand,
+			exportCommand,
+			dumpChainConfigCommand,
+			removedbCommand,
+			dumpCommand,
+			rollbackCommand,
+			recoverCommand,
+			resetCommand,
+		},
 		Flags: []cli.Flag{
 			DataDirFlag,
 			ChainIdentityFlag,
@@ -70,6 +92,10 @@ var AppHelpFlagGroups = []flagGroup{
 	},
 	{
 		Name: "ACCOUNT",
+		Commands: []cli.Command{
+			accountCommand,
+			walletCommand,
+		},
 		Flags: []cli.Flag{
 			UnlockedAccountFlag,
 			PasswordFileFlag,
@@ -78,6 +104,12 @@ var AppHelpFlagGroups = []flagGroup{
 	},
 	{
 		Name: "API AND CONSOLE",
+		Commands: []cli.Command{
+			consoleCommand,
+			attachCommand,
+			javascriptCommand,
+			apiCommand,
+		},
 		Flags: []cli.Flag{
 			RPCEnabledFlag,
 			RPCListenAddrFlag,
@@ -112,6 +144,9 @@ var AppHelpFlagGroups = []flagGroup{
 	},
 	{
 		Name: "MINER",
+		Commands: []cli.Command{
+			makeDagCommand,
+		},
 		Flags: []cli.Flag{
 			MiningEnabledFlag,
 			MinerThreadsFlag,
@@ -136,6 +171,14 @@ var AppHelpFlagGroups = []flagGroup{
 	},
 	{
 		Name: "LOGGING AND DEBUGGING",
+		Commands: []cli.Command{
+			versionCommand,
+			statusCommand,
+			monitorCommand,
+			makeMlogDocCommand,
+			gpuInfoCommand,
+			gpuBenchCommand,
+		},
 		Flags: []cli.Flag{
 			VerbosityFlag,
 			VModuleFlag,
@@ -147,6 +190,9 @@ var AppHelpFlagGroups = []flagGroup{
 			LogMaxAgeFlag,
 			LogCompressFlag,
 			LogStatusFlag,
+			DisplayFlag,
+			DisplayFormatFlag,
+			NeckbeardFlag,
 			MLogFlag,
 			MLogDirFlag,
 			MLogComponentsFlag,
@@ -160,13 +206,13 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			WhisperEnabledFlag,
 			NatspecEnabledFlag,
-			DisplayFlag,
-			DisplayFormatFlag,
-			NeckbeardFlag,
 		},
 	},
 	{
 		Name: "LEGACY",
+		Commands: []cli.Command{
+			upgradedbCommand,
+		},
 		Flags: []cli.Flag{
 			TestNetFlag,
 			Unused1,
@@ -186,8 +232,8 @@ func init() {
 
 	// Define a one shot struct to pass to the usage template
 	type helpData struct {
-		App        interface{}
-		FlagGroups []flagGroup
+		App                  interface{}
+		CommandAndFlagGroups []flagGroup
 	}
 	// Override the default app help printer, but only for the global app help
 	originalHelpPrinter := cli.HelpPrinter
@@ -195,7 +241,7 @@ func init() {
 		if tmpl == AppHelpTemplate {
 			// Iterate over all the flags and add any uncategorized ones
 			categorized := make(map[string]struct{})
-			for _, group := range AppHelpFlagGroups {
+			for _, group := range AppHelpFlagAndCommandGroups {
 				for _, flag := range group.Flags {
 					categorized[flag.String()] = struct{}{}
 				}
@@ -208,16 +254,16 @@ func init() {
 			}
 			if len(uncategorized) > 0 {
 				// Append all ungategorized options to the misc group
-				miscs := len(AppHelpFlagGroups[len(AppHelpFlagGroups)-1].Flags)
-				AppHelpFlagGroups[len(AppHelpFlagGroups)-1].Flags = append(AppHelpFlagGroups[len(AppHelpFlagGroups)-1].Flags, uncategorized...)
+				miscs := len(AppHelpFlagAndCommandGroups[len(AppHelpFlagAndCommandGroups)-1].Flags)
+				AppHelpFlagAndCommandGroups[len(AppHelpFlagAndCommandGroups)-1].Flags = append(AppHelpFlagAndCommandGroups[len(AppHelpFlagAndCommandGroups)-1].Flags, uncategorized...)
 
 				// Make sure they are removed afterwards
 				defer func() {
-					AppHelpFlagGroups[len(AppHelpFlagGroups)-1].Flags = AppHelpFlagGroups[len(AppHelpFlagGroups)-1].Flags[:miscs]
+					AppHelpFlagAndCommandGroups[len(AppHelpFlagAndCommandGroups)-1].Flags = AppHelpFlagAndCommandGroups[len(AppHelpFlagAndCommandGroups)-1].Flags[:miscs]
 				}()
 			}
 			// Render out custom usage screen
-			originalHelpPrinter(w, tmpl, helpData{data, AppHelpFlagGroups})
+			originalHelpPrinter(w, tmpl, helpData{data, AppHelpFlagAndCommandGroups})
 		} else {
 			originalHelpPrinter(w, tmpl, data)
 		}

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -70,7 +70,6 @@ var AppHelpFlagAndCommandGroups = []flagGroup{
 			importCommand,
 			exportCommand,
 			dumpChainConfigCommand,
-			removedbCommand,
 			dumpCommand,
 			rollbackCommand,
 			recoverCommand,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -78,15 +78,14 @@ var AppHelpFlagAndCommandGroups = []flagGroup{
 		Flags: []cli.Flag{
 			DataDirFlag,
 			ChainIdentityFlag,
-			KeyStoreDirFlag,
 			NetworkIdFlag,
 			DevModeFlag,
 			NodeNameFlag,
 			FastSyncFlag,
-			LightKDFFlag,
 			CacheFlag,
-			BlockchainVersionFlag,
+			LightKDFFlag,
 			SputnikVMFlag,
+			BlockchainVersionFlag,
 		},
 	},
 	{
@@ -96,6 +95,7 @@ var AppHelpFlagAndCommandGroups = []flagGroup{
 			walletCommand,
 		},
 		Flags: []cli.Flag{
+			KeyStoreDirFlag,
 			UnlockedAccountFlag,
 			PasswordFileFlag,
 			AccountsIndexFlag,


### PR DESCRIPTION
- remove requirement to use `--index-accounts` flag in conjunction with `geth account index` command. 
- improve (re-format) CLI usage output
- remove `remove-db` command; it was entirely redundant to `reset` command, and was broken anyways

rel #377 

yields `--help` output:

```
NAME:
   geth - the go-ethereum command line interface

USAGE:
   geth [options] <command> [command options] [arguments...]

VERSION:
   whilei.v5.1.0+5-316c0f8[branch=feat/improve-help-documentation,commit=problem:---keystore-flag-usage-should-be-in-'account'-category,built=Mar/29Thu-09:28:46]

COMMANDS AND FLAGS:
------------------------------------------------------------------------
ETHEREUM
------------------------------------------------------------------------
  
    import					Import a blockchain file
    export					Export blockchain into file
    dump-chain-config, dumpchainconfig		Dump current chain configuration to JSON file [REQUIRED argument: filepath.json]
    dump					Dump a specific block from storage
    rollback, roll-back, set-head, sethead	Set current head for blockchain, purging antecedent blocks
    recover					Attempt blockchain data recovery in case of data corruption
    reset					Reset (remove) the chain database
  
  --data-dir, --datadir "/Users/ia/Library/EthereumClassic"	Data directory for the databases and keystore
  --chain value							Chain identifier (default='mainnet', test='morden') or path to JSON chain configuration file (eg './path/to/chain.json'). (default: "mainnet")
  --network-id value, --networkid value				Network identifier (integer: 1=Homestead, 2=Morden) (default: 1)
  --dev								Developer mode: pre-configured private network with several debugging flags
  --identity value, --name value				Custom node name
  --fast							Enable fast syncing through state downloads
  --cache value							Megabytes of memory allocated to internal caching (min 16MB / database forced) (default: 128)
  --light-kdf, --lightkdf					Reduce key-derivation RAM & CPU usage at some expense of KDF strength
  --sputnikvm							Use SputnikVM Ethereum Virtual Machine implementation
  --blockchain-version value, --blockchainversion value		Blockchain version (integer) (default: 3)
  
ACCOUNT
------------------------------------------------------------------------
  
    account	Manage accounts

	list	Print account addresses
	new	Create a new account
	update	Update an existing account
	import	Import a private key into a new account
	index	Build persistent account index

    wallet	Ethereum presale wallet

	import	import ethereum presale wallet

  
  --keystore 				Directory path for the keystore
  --unlock value			Comma separated list of accounts to unlock
  --password value			Password file to use for non-inteactive password input
  --index-accounts, --indexaccounts	Enable key-value db store for indexing large amounts of key files
  
API AND CONSOLE
------------------------------------------------------------------------
  
    console	Geth Console: interactive JavaScript environment
    attach	Geth Console: interactive JavaScript environment (connect to node)
    js		Executes the given JavaScript files in the Geth JavaScript VM
    api		Run any API command
  
  --rpc							Enable the HTTP-RPC server
  --rpc-addr value, --rpcaddr value			HTTP-RPC server listening interface (default: "localhost")
  --rpc-port value, --rpcport value			HTTP-RPC server listening port (default: 8545)
  --rpc-api value, --rpcapi value			API's offered over the HTTP-RPC interface (default: "eth,net,web3")
  --ws							Enable the WS-RPC server
  --ws-addr value, --wsaddr value			WS-RPC server listening interface (default: "localhost")
  --ws-port value, --wsport value			WS-RPC server listening port (default: 8546)
  --ws-api value, --wsapi value				API's offered over the WS-RPC interface (default: "eth,net,web3")
  --ws-origins value, --wsorigins value			Origins from which to accept websockets requests
  --ipc-disable, --ipcdisable				Disable the IPC-RPC server
  --ipc-api value, --ipcapi value			API's offered over the IPC-RPC interface (default: "admin,debug,eth,miner,net,personal,shh,txpool,web3")
  --ipc-path, --ipcpath "geth.ipc"			Filename for IPC socket/pipe within the datadir (explicit paths escape it)
  --rpc-cors-domain value, --rpccorsdomain value	Comma separated list of domains from which to accept cross origin requests (browser enforced)
  --js-path loadScript, --jspath loadScript		JavaScript root path for loadScript and document root for `admin.httpGet` (default: ".")
  --exec value						Execute JavaScript statement (only in combination with console/attach)
  --preload value					Comma separated list of JavaScript files to preload into the console
  
NETWORKING
------------------------------------------------------------------------
  --bootnodes value				Comma separated enode URLs for P2P discovery bootstrap
  --port value					Network listening port (default: 30303)
  --max-peers value, --maxpeers value		Maximum number of network peers (network disabled if set to 0) (default: 25)
  --max-pend-peers value, --maxpendpeers value	Maximum number of pending connection attempts (defaults used if set to 0) (default: 0)
  --nat value					NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: "any")
  --no-discover, --nodiscover			Disables the peer discovery mechanism (manual peer addition)
  --nodekey value				P2P node key file
  --nodekey-hex value, --nodekeyhex value	P2P node key as hex (for testing)
  
MINER
------------------------------------------------------------------------
  
    make-dag, makedag	Generate ethash dag (for testing)
  
  --mine						Enable mining
  --miner-threads value, --minerthreads value		Number of CPU threads to use for mining (default: 2)
  --miner-gpus value, --minergpus value			List of GPUs to use for mining (e.g. '0,1' will use the first two GPUs found)
  --auto-dag, --autodag					Enable automatic DAG pregeneration
  --etherbase value					Public address for block mining rewards (default = first account created) (default: "0")
  --target-gas-limit value, --targetgaslimit value	Target gas limit sets the artificial target gas floor for the blocks to mine (default: "4712388")
  --gas-price value, --gasprice value			Minimal gas price to accept for mining a transactions (default: "20000000000")
  --extra-data value, --extradata value			Freeform header field set by the miner
  
GAS PRICE ORACLE
------------------------------------------------------------------------
  --gpo-min value, --gpomin value		Minimum suggested gas price (default: "20000000000")
  --gpo-max value, --gpomax value		Maximum suggested gas price (default: "500000000000")
  --gpo-full value, --gpofull value		Full block threshold for gas price calculation (%) (default: 80)
  --gpo-base-down value, --gpobasedown value	Suggested gas price base step down ratio (1/1000) (default: 10)
  --gpo-base-up value, --gpobaseup value	Suggested gas price base step up ratio (1/1000) (default: 100)
  --gpo-base-cf value, --gpobasecf value	Suggested gas price base correction factor (%) (default: 110)
  
LOGGING AND DEBUGGING
------------------------------------------------------------------------
  
    version		Print ethereum version numbers
    status		Display the status of the current node
    monitor		Geth Monitor: node metrics monitoring and visualization
    mdoc		Generate mlog documentation
    gpu-info, gpuinfo	GPU info
    gpu-bench, gpubench	Benchmark GPU
  
  --verbosity value						Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=core, 5=debug, 6=detail (default: 5)
  --vmodule value						Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=6,p2p=5)
  --log-dir value, --logdir value				Directory in which to write log files (default: "/Users/ia/Library/EthereumClassic/<chain>/log")
  --log-max-size value, --log-maxsize value			Maximum size of a single log file (in bytes) (default: "30M")
  --log-min-size value, --log-minsize value			Minimum size of a log file, to be considered for log-rotation (in bytes) (default: "0")
  --log-total-max-size value, --log-totalmaxsize value		Maximum total size of all (current and archived) log files (in bytes) (default: "0")
  --log-rotation-interval value					Log rotation interval, one of values: never, hourly, daily, weekly, monthly (default: "hourly")
  --log-max-age value, --log-maxage value			Maximum age of the oldest log file, valid time units: h, d, w (hours, days, weeks) (default: "0")
  --log-compress, --log-gzip					Enable/disable GZIP compression of archived log files (enabled by default)
  --log-status value						Configure interval-based status logs: comma-separated list of <pattern>=<interval>. Use 'off' or '0' to disable. (default: "sync=60s")
  --display value						Display verbosity: 0=silent, 1=basics, 2=status, 3=status+events (default: 3)
  --display-fmt value						Display format (experimental). Current possible values are [basic|green|dash]. (default: "basic")
  --neckbeard							Use verbose->stderr defaults for logging (verbosity=5,log-status='sync=60')
  --mlog value							Set machine-readable log format: [plain|kv|json|off] (default: "off")
  --mlog-dir "/Users/ia/Library/EthereumClassic/mainnet/mlogs"	Directory in which to write machine log files
  --mlog-components value					Set machine-readable logging components, comma-separated. 
								Use a '!'-prefix to disabled listed components instead. (default: "blockchain,txpool,downloader,fetcher,discover,server,state,headerchain,miner,client,wire")
  --backtrace value						Request a stack trace at a specific logging statement (e.g. "block.go:271") (default: :0)
  --metrics value						Enables metrics reporting. When the value is a path, either relative or absolute, then a log is written to the respective file.
  --fake-pow, --fakepow						Disables proof-of-work verification
  
EXPERIMENTAL
------------------------------------------------------------------------
  --shh		Enable Whisper
  --natspec	Enable NatSpec confirmation notice
  
LEGACY
------------------------------------------------------------------------
  
    upgrade-db, upgradedb	Upgrade chainblock database
  
  --testnet		[Use: --chain=morden] Morden network: pre-configured test network with modified starting nonces (replay protection)
  --oppose-dao-fork	Use classic blockchain (always set, flag is unused and exists for compatibility only)
  
MISCELLANEOUS
------------------------------------------------------------------------
  --solc value				Solidity compiler command to be used (default: "solc")
  --pprof value				Enable runtime profiling with web interface (default: 0)
  --pprof-interval value		Set interval in seconds for runtime profiling (default: 5)
  --doc-root, --docroot "/Users/ia"	Document Root for HTTPClient file scheme
  --help, -h				show help
  

```