### PR TITLE
chain config globals -> core/, fix requiredHash check and extensibility

### DIFF
--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -81,7 +81,7 @@ func StartNode(stack *node.Node) {
 
 	// mlog
 	nodeInfo := stack.Server().NodeInfo()
-	cconf := CacheChainConfig
+	cconf := core.GetCacheChainConfig()
 	if cconf == nil {
 		Fatalf("Nil chain configuration")
 	}
@@ -636,7 +636,7 @@ func rollback(ctx *cli.Context) error {
 func dumpChainConfig(ctx *cli.Context) error {
 
 	chainIdentity := mustMakeChainIdentity(ctx)
-	if !(ChainIdentitiesMain[chainIdentity] || ChainIdentitiesMorden[chainIdentity]) {
+	if !(core.ChainIdentitiesMain[chainIdentity] || core.ChainIdentitiesMorden[chainIdentity]) {
 		glog.Fatal("Dump config should only be used with default chain configurations (mainnet or morden).")
 	}
 

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -81,7 +81,7 @@ func StartNode(stack *node.Node) {
 
 	// mlog
 	nodeInfo := stack.Server().NodeInfo()
-	cconf := cacheChainConfig
+	cconf := CacheChainConfig
 	if cconf == nil {
 		Fatalf("Nil chain configuration")
 	}
@@ -636,7 +636,7 @@ func rollback(ctx *cli.Context) error {
 func dumpChainConfig(ctx *cli.Context) error {
 
 	chainIdentity := mustMakeChainIdentity(ctx)
-	if !(chainIdentitiesMain[chainIdentity] || chainIdentitiesMorden[chainIdentity]) {
+	if !(ChainIdentitiesMain[chainIdentity] || ChainIdentitiesMorden[chainIdentity]) {
 		glog.Fatal("Dump config should only be used with default chain configurations (mainnet or morden).")
 	}
 

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -84,27 +84,7 @@ var (
 	ErrDirectoryStructure = errors.New("error in directory structure")
 	ErrStackFail          = errors.New("error in stack protocol")
 
-	// Chain identities.
-	chainIdentitiesBlacklist = map[string]bool{
-		"chaindata": true,
-		"dapp":      true,
-		"keystore":  true,
-		"nodekey":   true,
-		"nodes":     true,
-	}
-	chainIdentitiesMain = map[string]bool{
-		"main":    true,
-		"mainnet": true,
-	}
-	chainIdentitiesMorden = map[string]bool{
-		"morden":  true,
-		"testnet": true,
-	}
-
 	devModeDataDirPath = filepath.Join(os.TempDir(), "/ethereum_dev_mode")
-
-	cacheChainIdentity string
-	cacheChainConfig   *core.SufficientChainConfig
 )
 
 // chainIsMorden allows either
@@ -114,14 +94,14 @@ func chainIsMorden(ctx *cli.Context) bool {
 	if ctx.GlobalBool(aliasableName(TestNetFlag.Name, ctx)) {
 		return true
 	}
-	if _, ok := chainIdentitiesMorden[cacheChainIdentity]; ok {
+	if _, ok := core.ChainIdentitiesMorden[core.GetCacheChainIdentity()]; ok {
 		return ok
 	}
-	if _, ok := chainIdentitiesMorden[ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx))]; ok {
+	if _, ok := core.ChainIdentitiesMorden[ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx))]; ok {
 		return ok
 	}
-	if cacheChainConfig != nil {
-		if _, ok := chainIdentitiesMorden[cacheChainConfig.Identity]; ok {
+	if c := core.GetCacheChainConfig(); c != nil {
+		if _, ok := core.ChainIdentitiesMorden[c.Identity]; ok {
 			return ok
 		}
 	}
@@ -155,8 +135,8 @@ func copyChainConfigFileToChainDataDir(ctx *cli.Context, identity, configFilePat
 // It returns one of valid strings: ["mainnet", "morden", or --chain="flaggedCustom"]
 func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 
-	if cacheChainIdentity != "" {
-		return cacheChainIdentity
+	if id := core.GetCacheChainIdentity(); id != "" {
+		return id
 	}
 
 	if ctx.GlobalIsSet(aliasableName(TestNetFlag.Name, ctx)) && ctx.GlobalIsSet(aliasableName(ChainIdentityFlag.Name, ctx)) {
@@ -166,7 +146,7 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 	}
 
 	defer func() {
-		cacheChainIdentity = identity
+		core.SetCacheChainIdentity(identity)
 	}()
 
 	if chainFlagVal := ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx)); chainFlagVal != "" {
@@ -180,12 +160,12 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 	}
 	// If --chain is in use.
 	if chainFlagVal := ctx.GlobalString(aliasableName(ChainIdentityFlag.Name, ctx)); chainFlagVal != "" {
-		if chainIdentitiesMain[chainFlagVal] {
+		if core.ChainIdentitiesMain[chainFlagVal] {
 			identity = core.DefaultConfigMainnet.Identity
 			return identity
 		}
 		// Check for disallowed values.
-		if chainIdentitiesBlacklist[chainFlagVal] {
+		if core.ChainIdentitiesBlacklist[chainFlagVal] {
 			glog.Fatalf(`%v: %v: reserved word
 					reserved words for --chain flag include: 'chaindata', 'dapp', 'keystore', 'nodekey', 'nodes',
 					please use a different identifier`, ErrInvalidFlag, core.ErrInvalidChainID)
@@ -204,7 +184,7 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 				}
 				// In edge case of using a config file for default configuration (decided by 'identity'),
 				// set global context and override config file.
-				if chainIdentitiesMorden[c.Identity] || chainIdentitiesMain[c.Identity] {
+				if core.ChainIdentitiesMorden[c.Identity] || core.ChainIdentitiesMain[c.Identity] {
 					if e := ctx.Set(aliasableName(ChainIdentityFlag.Name, ctx), c.Identity); e != nil {
 						glog.Fatalf("Could not set global context chain identity to morden, error: %v", e)
 					}
@@ -533,7 +513,7 @@ func MakeSystemNode(version string, ctx *cli.Context) *node.Node {
 // should attempt to migration from old (<=3.3) directory schema to new.
 func shouldAttemptDirMigration(ctx *cli.Context) bool {
 	if !ctx.GlobalIsSet(aliasableName(DataDirFlag.Name, ctx)) {
-		if chainVal := mustMakeChainIdentity(ctx); chainIdentitiesMain[chainVal] || chainIdentitiesMorden[chainVal] {
+		if chainVal := mustMakeChainIdentity(ctx); core.ChainIdentitiesMain[chainVal] || core.ChainIdentitiesMorden[chainVal] {
 			return true
 		}
 	}
@@ -655,8 +635,8 @@ func mustMakeEthConf(ctx *cli.Context, sconf *core.SufficientChainConfig) *eth.C
 // reading a file a couple of times was more efficient than storing a global.
 func mustMakeSufficientChainConfig(ctx *cli.Context) *core.SufficientChainConfig {
 
-	if cacheChainConfig != nil {
-		return cacheChainConfig
+	if c := core.GetCacheChainConfig(); c != nil {
+		return c
 	}
 
 	config := &core.SufficientChainConfig{}
@@ -679,13 +659,13 @@ func mustMakeSufficientChainConfig(ctx *cli.Context) *core.SufficientChainConfig
 			}
 			config.Network = i
 		}
-		cacheChainConfig = config
+		core.SetCacheChainConfig(config)
 	}()
 
 	chainIdentity := mustMakeChainIdentity(ctx)
 
 	// If chain identity is either of defaults (via config file or flag), use defaults.
-	if chainIdentitiesMain[chainIdentity] || chainIdentitiesMorden[chainIdentity] {
+	if core.ChainIdentitiesMain[chainIdentity] || core.ChainIdentitiesMorden[chainIdentity] {
 		// Initialise chain configuration before handling migrations or setting up node.
 		config.Identity = chainIdentity
 		config.Name = mustMakeChainConfigNameDefaulty(ctx)
@@ -739,7 +719,7 @@ func mustMakeSufficientChainConfig(ctx *cli.Context) *core.SufficientChainConfig
 
 func logChainConfiguration(ctx *cli.Context, config *core.SufficientChainConfig) {
 	chainIdentity := mustMakeChainIdentity(ctx)
-	chainIsCustom := !(chainIdentitiesMain[chainIdentity] || chainIdentitiesMorden[chainIdentity])
+	chainIsCustom := !(core.ChainIdentitiesMain[chainIdentity] || core.ChainIdentitiesMorden[chainIdentity])
 
 	// File logs.
 	// TODO: uglify V logs? provide more detail for debugging? normal users won't see this.

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -79,8 +79,8 @@ OPTIONS:
 
 var (
 	// Errors.
-	ErrInvalidFlag        = errors.New("invalid flag or context value")
-	ErrInvalidChainID     = errors.New("invalid chainID")
+	ErrInvalidFlag = errors.New("invalid flag or context value")
+
 	ErrDirectoryStructure = errors.New("error in directory structure")
 	ErrStackFail          = errors.New("error in stack protocol")
 
@@ -188,7 +188,7 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 		if chainIdentitiesBlacklist[chainFlagVal] {
 			glog.Fatalf(`%v: %v: reserved word
 					reserved words for --chain flag include: 'chaindata', 'dapp', 'keystore', 'nodekey', 'nodes',
-					please use a different identifier`, ErrInvalidFlag, ErrInvalidChainID)
+					please use a different identifier`, ErrInvalidFlag, core.ErrInvalidChainID)
 			identity = ""
 			return identity
 		}
@@ -219,7 +219,7 @@ func mustMakeChainIdentity(ctx *cli.Context) (identity string) {
 		identity = chainFlagVal
 		return identity
 	} else if ctx.GlobalIsSet(aliasableName(ChainIdentityFlag.Name, ctx)) {
-		glog.Fatalf("%v: %v: chainID empty", ErrInvalidFlag, ErrInvalidChainID)
+		glog.Fatalf("%v: %v: chainID empty", ErrInvalidFlag, core.ErrInvalidChainID)
 		identity = ""
 		return identity
 	}
@@ -724,7 +724,7 @@ func mustMakeSufficientChainConfig(ctx *cli.Context) *core.SufficientChainConfig
 
 	// Ensure JSON 'id' value matches name of parent chain subdir.
 	if config.Identity != chainIdentity {
-		glog.Fatalf(`%v: JSON 'id' value in external config file (%v) must match name of parent subdir (%v)`, ErrInvalidChainID, config.Identity, chainIdentity)
+		glog.Fatalf(`%v: JSON 'id' value in external config file (%v) must match name of parent subdir (%v)`, core.ErrInvalidChainID, config.Identity, chainIdentity)
 	}
 
 	// Set statedb StartingNonce from external config, if specified (is optional)

--- a/cmd/geth/flag_test.go
+++ b/cmd/geth/flag_test.go
@@ -143,7 +143,7 @@ func TestMustMakeChainDataDir(t *testing.T) {
 
 	for _, c := range cases {
 		// Unset cache.
-		cacheChainIdentity = ""
+		CacheChainIdentity = ""
 
 		setupFlags(t)
 
@@ -194,7 +194,7 @@ func TestGetChainIdentityValue(t *testing.T) {
 
 	for _, c := range cases {
 		// Unset cache.
-		cacheChainIdentity = ""
+		CacheChainIdentity = ""
 
 		setupFlags(t)
 

--- a/cmd/geth/flag_test.go
+++ b/cmd/geth/flag_test.go
@@ -143,7 +143,7 @@ func TestMustMakeChainDataDir(t *testing.T) {
 
 	for _, c := range cases {
 		// Unset cache.
-		CacheChainIdentity = ""
+		core.SetCacheChainIdentity("")
 
 		setupFlags(t)
 
@@ -194,7 +194,7 @@ func TestGetChainIdentityValue(t *testing.T) {
 
 	for _, c := range cases {
 		// Unset cache.
-		CacheChainIdentity = ""
+		core.SetCacheChainIdentity("")
 
 		setupFlags(t)
 

--- a/cmd/geth/log_display_dash.go
+++ b/cmd/geth/log_display_dash.go
@@ -98,8 +98,8 @@ func tuiDrawDash(e *eth.Ethereum) {
 		cid := e.ChainConfig().GetChainID()
 		cnet := e.NetVersion()
 		cname := ""
-		if CacheChainIdentity != "" {
-			cname = CacheChainIdentity
+		if id := core.GetCacheChainIdentity(); id != "" {
+			cname = id
 		}
 		headerInfo.Text = fmt.Sprintf(" Mode=%s Chain=%v(%d) Chain Id=%d \n"+
 			" local_head ◼ n=%d ⬡=%s txs=%d time=%v ago",

--- a/cmd/geth/log_display_dash.go
+++ b/cmd/geth/log_display_dash.go
@@ -98,8 +98,8 @@ func tuiDrawDash(e *eth.Ethereum) {
 		cid := e.ChainConfig().GetChainID()
 		cnet := e.NetVersion()
 		cname := ""
-		if cacheChainIdentity != "" {
-			cname = cacheChainIdentity
+		if CacheChainIdentity != "" {
+			cname = CacheChainIdentity
 		}
 		headerInfo.Text = fmt.Sprintf(" Mode=%s Chain=%v(%d) Chain Id=%d \n"+
 			" local_head ◼ n=%d ⬡=%s txs=%d time=%v ago",

--- a/cmd/geth/migrate_datadir.go
+++ b/cmd/geth/migrate_datadir.go
@@ -223,7 +223,7 @@ func migrateToChainSubdirIfNecessary(ctx *cli.Context) error {
 	}
 
 	// 3.3 testnet uses subdir '/testnet'
-	if chainIdentitiesMorden[chainIdentity] {
+	if ChainIdentitiesMorden[chainIdentity] {
 		exTestDir := filepath.Join(subdirPath, "../testnet")
 		exTestDirInfo, e := os.Stat(exTestDir)
 		if e != nil && os.IsNotExist(e) {

--- a/cmd/geth/migrate_datadir.go
+++ b/cmd/geth/migrate_datadir.go
@@ -223,7 +223,7 @@ func migrateToChainSubdirIfNecessary(ctx *cli.Context) error {
 	}
 
 	// 3.3 testnet uses subdir '/testnet'
-	if ChainIdentitiesMorden[chainIdentity] {
+	if core.ChainIdentitiesMorden[chainIdentity] {
 		exTestDir := filepath.Join(subdirPath, "../testnet")
 		exTestDirInfo, e := os.Stat(exTestDir)
 		if e != nil && os.IsNotExist(e) {

--- a/core/config.go
+++ b/core/config.go
@@ -47,6 +47,8 @@ var (
 	ErrChainConfigNotFound     = errors.New("chain config not found")
 	ErrChainConfigForkNotFound = errors.New("chain config fork not found")
 
+	ErrInvalidChainID = errors.New("invalid chainID")
+
 	ErrHashKnownBad  = errors.New("known bad hash")
 	ErrHashKnownFork = validateError("known fork hash mismatch")
 )

--- a/core/config.go
+++ b/core/config.go
@@ -51,7 +51,44 @@ var (
 
 	ErrHashKnownBad  = errors.New("known bad hash")
 	ErrHashKnownFork = validateError("known fork hash mismatch")
+
+	// Chain identities.
+	ChainIdentitiesBlacklist = map[string]bool{
+		"chaindata": true,
+		"dapp":      true,
+		"keystore":  true,
+		"nodekey":   true,
+		"nodes":     true,
+	}
+	ChainIdentitiesMain = map[string]bool{
+		"main":    true,
+		"mainnet": true,
+	}
+	ChainIdentitiesMorden = map[string]bool{
+		"morden":  true,
+		"testnet": true,
+	}
+
+	cacheChainIdentity string
+	cacheChainConfig   *SufficientChainConfig
 )
+
+func SetCacheChainIdentity(s string) {
+	cacheChainIdentity = s
+}
+
+func GetCacheChainIdentity() string {
+	return cacheChainIdentity
+}
+
+func SetCacheChainConfig(c *SufficientChainConfig) *SufficientChainConfig {
+	cacheChainConfig = c
+	return cacheChainConfig
+}
+
+func GetCacheChainConfig() *SufficientChainConfig {
+	return cacheChainConfig
+}
 
 // SufficientChainConfig holds necessary data for externalizing a given blockchain configuration.
 type SufficientChainConfig struct {

--- a/core/config.go
+++ b/core/config.go
@@ -408,6 +408,24 @@ func (c *ChainConfig) HeaderCheck(h *types.Header) error {
 	return nil
 }
 
+// GetLatestRequiredHash returns the latest requiredHash from chain config for a given blocknumber n (eg. bc head).
+// It does NOT depend on forks being sorted.
+func (c *ChainConfig) GetLatestRequiredHashFork(n *big.Int) (f *Fork) {
+	lastBlockN := new(big.Int)
+	for _, ff := range c.Forks {
+		if ff.RequiredHash.IsEmpty() {
+			continue
+		}
+		// If this fork is chronologically later than lastSet fork with required hash AND given block n is greater than
+		// the fork.
+		if ff.Block.Cmp(lastBlockN) > 0 && n.Cmp(ff.Block) >= 0 {
+			f = ff
+			lastBlockN = ff.Block
+		}
+	}
+	return
+}
+
 func (c *ChainConfig) GetSigner(blockNumber *big.Int) types.Signer {
 	feature, _, configured := c.GetFeature(blockNumber, "eip155")
 	if configured {

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -559,13 +559,13 @@ func TestChainConfig_GetLastRequiredHashFork(t *testing.T) {
 	}
 
 	if got == nil {
-		t.Fatalf("got: %v, want: %s", got, want)
+		t.Fatalf("got: %v, want: %s", got, want.Name)
 	}
 	if got.RequiredHash.Hex() != "0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f" {
 		t.Errorf("got: %v, want: %s", got, got.RequiredHash.Hex())
 	}
 	if got.Block.Cmp(big.NewInt(1920000)) != 0 {
-		t.Errorf("got: %v, want: %v", got.Block, 1920000)
+		t.Errorf("got: %d, want: %d", got.Block, 1920000)
 	}
 
 	// create new "checkpoint" fork for testing

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -584,7 +584,7 @@ func TestChainConfig_GetLastRequiredHashFork(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
-	// should use dao fork, not checkpoint since (peer) "head" has not reached checkpoint
+	// should use dao fork, not checkpoint since block n has not reached checkpoint
 	got, want = c.GetLatestRequiredHashFork(big.NewInt(1920001)), daoFork
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got: %v, want: %v", got, want)

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -6,8 +6,10 @@ import (
 
 	"path/filepath"
 
+	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/ethereumproject/go-ethereum/core/types"
 	"github.com/ethereumproject/go-ethereum/ethdb"
+	"reflect"
 )
 
 func TestConfigErrorProperties(t *testing.T) {
@@ -510,6 +512,82 @@ func TestChainConfig_SortForks(t *testing.T) {
 			t.Errorf("unexpected fork block: %v is greater than: %v", fork.Block, n)
 		}
 		n = fork.Block
+	}
+}
+
+func TestChainConfigGetSet(t *testing.T) {
+	c := getDefaultChainConfigSorted()
+	set := SetCacheChainConfig(&SufficientChainConfig{ChainConfig: c})
+
+	if set == nil {
+		t.Fatal("set returned nil")
+	}
+
+	got := GetCacheChainConfig()
+	if got == nil {
+		t.Fatal("get returned nil")
+	}
+
+	// create new "checkpoint" fork for testing
+	checkpoint := &Fork{
+		Name:         "checkpoint",
+		Block:        big.NewInt(1930000),
+		RequiredHash: common.HexToHash("0xabc65e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ad123"),
+	}
+	c.Forks = append(c.Forks, checkpoint)
+
+	got.ChainConfig.Forks = c.Forks
+	didSet := SetCacheChainConfig(got)
+	if !reflect.DeepEqual(got, didSet) {
+		t.Errorf("got: %v, want: %v", didSet, got)
+	}
+
+	if f := set.ChainConfig.ForkByName("checkpoint"); f == nil {
+		t.Errorf("got: %v, want: %v", f, checkpoint)
+	}
+}
+
+func TestChainConfig_GetLastRequiredHashFork(t *testing.T) {
+	c := getDefaultChainConfigSorted()
+
+	daoFork := c.ForkByName("The DAO Hard Fork")
+	got, want := c.GetLatestRequiredHashFork(big.NewInt(1920000)), daoFork
+
+	// sanity check
+	if want == nil {
+		t.Fatal("nil want hard fork")
+	}
+
+	if got == nil {
+		t.Fatalf("got: %v, want: %s", got, want)
+	}
+	if got.RequiredHash.Hex() != "0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f" {
+		t.Errorf("got: %v, want: %s", got, got.RequiredHash.Hex())
+	}
+	if got.Block.Cmp(big.NewInt(1920000)) != 0 {
+		t.Errorf("got: %v, want: %v", got.Block, 1920000)
+	}
+
+	// create new "checkpoint" fork for testing
+	checkpoint := &Fork{
+		Name:         "checkpoint",
+		Block:        big.NewInt(1930000),
+		RequiredHash: common.HexToHash("0xabc65e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ad123"),
+	}
+	c.Forks = append(c.Forks, checkpoint)
+
+	// Noting that config forks do not have to be sorted for this function to work.
+	//c.SortForks()
+
+	got, want = c.GetLatestRequiredHashFork(big.NewInt(1930000)), checkpoint
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+
+	// should use dao fork, not checkpoint since (peer) "head" has not reached checkpoint
+	got, want = c.GetLatestRequiredHashFork(big.NewInt(1920001)), daoFork
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -32,9 +32,9 @@ import (
 	"github.com/ethereumproject/go-ethereum/core/types"
 	"github.com/ethereumproject/go-ethereum/ethdb"
 	"github.com/ethereumproject/go-ethereum/event"
-	"github.com/ethereumproject/go-ethereum/metrics"
 	"github.com/ethereumproject/go-ethereum/logger"
 	"github.com/ethereumproject/go-ethereum/logger/glog"
+	"github.com/ethereumproject/go-ethereum/metrics"
 )
 
 const (
@@ -65,12 +65,12 @@ var (
 	maxHeadersProcess = 2048      // Number of header download results to import at once into the chain
 	maxResultsProcess = 2048      // Number of content download results to import at once into the chain
 
-	fsHeaderCheckFrequency = 100  // Verification frequency of the downloaded headers during fast sync
-	fsHeaderSafetyNet      = 2048 // Number of headers to discard in case a chain violation is detected
-	fsHeaderForceVerify    = 24   // Number of headers to verify before and after the pivot to accept it
-	fsPivotInterval        = 512  // Number of headers out of which to randomize the pivot point
-	fsMinFullBlocks        = 1024 // Number of blocks to retrieve fully even in fast sync
-	fsCriticalTrials uint32      = 10   // Number of times to retry in the cricical section before bailing
+	fsHeaderCheckFrequency        = 100  // Verification frequency of the downloaded headers during fast sync
+	fsHeaderSafetyNet             = 2048 // Number of headers to discard in case a chain violation is detected
+	fsHeaderForceVerify           = 24   // Number of headers to verify before and after the pivot to accept it
+	fsPivotInterval               = 512  // Number of headers out of which to randomize the pivot point
+	fsMinFullBlocks               = 1024 // Number of blocks to retrieve fully even in fast sync
+	fsCriticalTrials       uint32 = 10   // Number of times to retry in the cricical section before bailing
 )
 
 var (
@@ -129,7 +129,7 @@ type Downloader struct {
 	stateDB ethdb.Database
 
 	fsPivotLock  *types.Header // Pivot header on critical section entry (cannot change between retries)
-	fsPivotFails uint32           // Number of fast sync failures in the critical section
+	fsPivotFails uint32        // Number of fast sync failures in the critical section
 
 	rttEstimate   uint64 // Round trip time to target for download requests
 	rttConfidence uint64 // Confidence in the estimated RTT (unit: millionths to allow atomic ops)
@@ -1412,8 +1412,8 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		items := int(math.Min(float64(len(results)), float64(maxResultsProcess)))
 		first, last := results[0].Header, results[items-1].Header
 		glog.V(logger.Debug).Infoln("Inserting downloaded chain", "items", len(results),
-			"firstnum", first.Number, "firsthash", first.Hash(),
-			"lastnum", last.Number, "lasthash", last.Hash(),
+			"firstnum", first.Number, "firsthash", first.Hash().Hex(),
+			"lastnum", last.Number, "lasthash", last.Hash().Hex(),
 		)
 		blocks := make([]*types.Block, items)
 		for i, result := range results[:items] {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -260,11 +260,11 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			headers = append(headers, pm.blockchain.GetBlock(hash).Header())
 		}
 		// Send the hash request and verify the response
-		s, _ := p2p.Send(peer.app, 0x03, tt.query)
+		s, _ := p2p.Send(peer.app, GetBlockHeadersMsg, tt.query)
 		if s == 0 {
 			t.Errorf("got: %v, want: >0", s)
 		}
-		if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
+		if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
 		// If the test used number origins, repeat with hashes as the too
@@ -272,11 +272,11 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 			if origin := pm.blockchain.GetBlockByNumber(tt.query.Origin.Number); origin != nil {
 				tt.query.Origin.Hash, tt.query.Origin.Number = origin.Hash(), 0
 
-				s, _ := p2p.Send(peer.app, 0x03, tt.query)
+				s, _ := p2p.Send(peer.app, GetBlockHeadersMsg, tt.query)
 				if s == 0 {
 					t.Errorf("got: %v, want: >0", s)
 				}
-				if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
+				if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, headers); err != nil {
 					t.Errorf("test %d: headers mismatch: %v", i, err)
 				}
 			}
@@ -349,11 +349,11 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 			}
 		}
 		// Send the hash request and verify the response
-		s, _ := p2p.Send(peer.app, 0x05, hashes)
+		s, _ := p2p.Send(peer.app, GetBlockBodiesMsg, hashes)
 		if s == 0 {
 			t.Errorf("got: %v, want: >0", s)
 		}
-		if err := p2p.ExpectMsg(peer.app, 0x06, bodies); err != nil {
+		if err := p2p.ExpectMsg(peer.app, BlockBodiesMsg, bodies); err != nil {
 			t.Errorf("test %d: bodies mismatch: %v", i, err)
 		}
 	}
@@ -409,7 +409,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 			hashes = append(hashes, common.BytesToHash(key))
 		}
 	}
-	s, _ := p2p.Send(peer.app, 0x0d, hashes)
+	s, _ := p2p.Send(peer.app, GetNodeDataMsg, hashes)
 	if s == 0 {
 		t.Errorf("got: %v, want: >0", s)
 	}
@@ -417,7 +417,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 	if err != nil {
 		t.Fatalf("failed to read node data response: %v", err)
 	}
-	if msg.Code != 0x0e {
+	if msg.Code != NodeDataMsg {
 		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, 0x0c)
 	}
 	var data [][]byte
@@ -505,11 +505,11 @@ func testGetReceipt(t *testing.T, protocol int) {
 		receipts = append(receipts, core.GetBlockReceipts(pm.chaindb, block.Hash()))
 	}
 	// Send the hash request and verify the response
-	s, _ := p2p.Send(peer.app, 0x0f, hashes)
+	s, _ := p2p.Send(peer.app, GetReceiptsMsg, hashes)
 	if s <= 0 {
 		t.Errorf("got: %v, want: >0", s)
 	}
-	if err := p2p.ExpectMsg(peer.app, 0x10, receipts); err != nil {
+	if err := p2p.ExpectMsg(peer.app, ReceiptsMsg, receipts); err != nil {
 		t.Errorf("receipts mismatch: %v", err)
 	}
 }

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -129,7 +129,7 @@ func TestShouldRequestRequiredHashHeader(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if n, got := pm.shouldRequestRequiredHashHeader(c.localHead, c.peerHead); n != c.wantN || got != c.wantB {
+		if n, got := pm.getRequiredHashBlockNumber(c.localHead, c.peerHead); n != c.wantN || got != c.wantB {
 			t.Errorf("%s -> wantN: %v, gotN: %v, wantB: %v, gotB: %v", c.name, c.wantN, n, c.wantB, got)
 		}
 	}


### PR DESCRIPTION
- move SufficientChainConfig and ChainIdentity vals from `cmd/geth` to `core` package and make accessible via getter/setter fns
- implement `core.GetLatestRequiredHashFork` fn to handle configs with multiple forks with `requiredHash`s. 
  + [ ] One idea around this would be to shift `requiredHash` configuration out of the `Fork` config and toward a simple `blockNumber: hash` key-val configuration, although would introduce complexity because of backwwards-compatibility requirements. Probably not worth it, and there are benefits to the additional configuration options provided by Fork syntax, and to reduce "checkpoint" multiplicity, a single "last-relevant" checkpoint could be used.
- fix `requiredHash` check for newly-registered `eth/*peers` (in eth/handler.go). See #559. Please give particular attention to review of this section.
