### PR TITLE
use deterministic K-value in ECDSA signing algorithm

### DIFF
--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -90,7 +90,7 @@ func TestSign(t *testing.T) {
 		t.Errorf("Sign error: %s", err)
 	}
 	if len(sig) != 65 {
-		t.Error("wrong len sig", len(sig))
+		t.Error("wrong signature length", len(sig))
 	}
 	recoveredPub, err := Ecrecover(msg, sig)
 	if err != nil {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -89,6 +89,9 @@ func TestSign(t *testing.T) {
 	if err != nil {
 		t.Errorf("Sign error: %s", err)
 	}
+	if len(sig) != 65 {
+		t.Error("wrong len sig", len(sig))
+	}
 	recoveredPub, err := Ecrecover(msg, sig)
 	if err != nil {
 		t.Errorf("ECRecover error: %s", err)


### PR DESCRIPTION
problem: nondeterministic K-value in ECDSA algo (crypto.Sign)
solution: move to a deterministic k-value using RFC6979

rel https://github.com/ethereum/go-ethereum/issues/2190
rel https://github.com/ethereum/go-ethereum/pull/3561
rel #245 

----

Before this change `eth_sign`, for example, would generate nondeterministic signatures, for example:
```
> var acc=eth.accounts[0];
undefined
> acc
"0x3d1cf2f13db48a49bc07ae7018826b6ea2ede093"
> personal.unlockAccount(acc);
Unlock account 0x3d1cf2f13db48a49bc07ae7018826b6ea2ede093
Passphrase:
true
> eth.sign(acc, "0xdeadbeef");
"0x527a0019b5ce8a99f7be59f2ec78b206f820699ff1b9f31b1cdc6fda781028272108210671dc6436eea267fb39cbb4c5e7e6a3d572f789417a693aeec14f2e0b1c"
> eth.sign(acc, "0xdeadbeef");
"0x38450e81a02f388a2c903453e4c5bee80da9eb134cc030a2cf515aff0f10eb177de6f1df907db85b84b4cebf2ebe28bd8c0da2ee541e463846c1502f00037f0c1c"
```

With this change, the signature becomes deterministic:
```
> personal.sign("0xdeadbeef", eth.accounts[0], "foo");
"0x33a614e8cbf323cb705711a1c43c9a8522b11bc07f22d8425e73aec2075d331408d2ce4df925e29e87dae8bc6c79bfe3baeb185f75d9fc1b60e1acb5f8122e171c"
> personal.sign("0xdeadbeef", eth.accounts[0], "foo");
"0x33a614e8cbf323cb705711a1c43c9a8522b11bc07f22d8425e73aec2075d331408d2ce4df925e29e87dae8bc6c79bfe3baeb185f75d9fc1b60e1acb5f8122e171c"
```