### PR TITLE
implement miner_setExtra API method

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/accounts"
 	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/ethereumproject/go-ethereum/common/compiler"
+	"github.com/ethereumproject/go-ethereum/common/hexutil"
 	"github.com/ethereumproject/go-ethereum/core"
 	"github.com/ethereumproject/go-ethereum/core/state"
 	"github.com/ethereumproject/go-ethereum/core/types"
@@ -296,6 +297,7 @@ func (s *PrivateMinerAPI) StopAutoDAG() bool {
 
 // StopAutoDAG stops auto DAG generation
 func (s *PrivateMinerAPI) SetExtra(b hexutil.Bytes) bool {
+	// types.HeaderExtraMax is the size limit for Header.Extra
 	if len(b) > types.HeaderExtraMax {
 		return false
 	}

--- a/eth/api.go
+++ b/eth/api.go
@@ -294,6 +294,15 @@ func (s *PrivateMinerAPI) StopAutoDAG() bool {
 	return true
 }
 
+// StopAutoDAG stops auto DAG generation
+func (s *PrivateMinerAPI) SetExtra(b hexutil.Bytes) bool {
+	if len(b) > types.HeaderExtraMax {
+		return false
+	}
+	miner.HeaderExtra = b
+	return true
+}
+
 // MakeDAG creates the new DAG for the given block number
 func (s *PrivateMinerAPI) MakeDAG(blockNr rpc.BlockNumber) (bool, error) {
 	if err := ethash.MakeDAG(uint64(blockNr.Int64()), ""); err != nil {


### PR DESCRIPTION
### problem
Documented `miner_setExtra` method is missing.
> https://github.com/ethereumproject/go-ethereum/wiki/JavaScript-Console#minersetextra

### solution
Add method to `*PrivateMinerAPI`. Like other private miner methods, the `setExtra` function returns a boolean; `true` if value is successfully set, otherwise `false.`

### example

```js
> miner.setExtra("0xdeadbeef");
true
```