### PR TITLE
bump db cache default val from 128 -> 1024mb

### DIFF
--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -83,7 +83,7 @@ var (
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
 		Usage: "Megabytes of memory allocated to internal caching (min 16MB / database forced)",
-		Value: 128,
+		Value: 1024,
 	}
 	BlockchainVersionFlag = cli.IntFlag{
 		Name:  "blockchain-version,blockchainversion",


### PR DESCRIPTION
IMO default 128mb is pretty tiny, and leads to defaultily slow syncing.

Moving to 1024mb default is on par with gethETC, though Parity appears to still use 128mb as of 1.9.7.