### PR TITLE
multivm/sputnikvm.RequireBlockhash: ensure block exists in db

### DIFF
--- a/core/multivm_processor.go
+++ b/core/multivm_processor.go
@@ -119,9 +119,11 @@ Loop:
 			vm.CommitNonexist(address)
 		case sputnikvm.RequireBlockhash:
 			number := ret.BlockNumber()
+			hash := common.Hash{}
 			if block := bc.GetBlockByNumber(number.Uint64()); block != nil && block.Number().Cmp(number) == 0 {
-				vm.CommitBlockhash(number, block.Hash())
+				hash = block.Hash()
 			}
+			vm.CommitBlockhash(number, hash)
 		}
 	}
 

--- a/core/multivm_processor.go
+++ b/core/multivm_processor.go
@@ -112,8 +112,8 @@ Loop:
 			key := common.BigToHash(ret.StorageKey())
 			if statedb.Exist(address) {
 				value := statedb.GetState(address, key).Big()
-				key := ret.StorageKey()
-				vm.CommitAccountStorage(address, key, value)
+				sKey := ret.StorageKey()
+				vm.CommitAccountStorage(address, sKey, value)
 				break
 			}
 			vm.CommitNonexist(address)

--- a/core/multivm_processor.go
+++ b/core/multivm_processor.go
@@ -119,8 +119,9 @@ Loop:
 			vm.CommitNonexist(address)
 		case sputnikvm.RequireBlockhash:
 			number := ret.BlockNumber()
-			hash := bc.GetBlockByNumber(number.Uint64()).Hash()
-			vm.CommitBlockhash(number, hash)
+			if block := bc.GetBlockByNumber(number.Uint64()); block != nil && block.Number().Cmp(number) == 0 {
+				vm.CommitBlockhash(number, block.Hash())
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes 

```
panic: runtime error: invalid memory address or nil pointer dereference                                   
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xaa0fa7]                                    

goroutine 188627 [running]:                          
sync/atomic.(*Value).Load(...)                       
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/core/types/block.go:398                 
github.com/ethereumproject/go-ethereum/core/types.(*Block).Hash(0x0, 0x0, 0x0, 0x0, 0x0)                  
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/core/types/block.go:398 +0x67           
github.com/ethereumproject/go-ethereum/core.ApplyMultiVmTransaction(0xc420427b90, 0xc421808360, 0xc43418aaa0, 0xc42bec9700, 0xc42b1b98c0, 0xc42a789400, 0xc43418a940, 0x160, 0x150, 0x10aa560, ...)                 
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/core/multivm_processor.go:122 +0x20c2   
github.com/ethereumproject/go-ethereum/core.(*StateProcessor).Process(0xc4217d23c0, 0xc433af3b00, 0xc42bec9700, 0x54154a23db5020e, 0x862a8d08c2cd782f, 0x0, 0x0, 0x0, 0x0, 0x0, ...)                                
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/core/state_processor.go:97 +0x45e       
github.com/ethereumproject/go-ethereum/core.(*BlockChain).InsertChain(0xc421808360, 0xc42c6e2000, 0x800, 0x800, 0x0, 0x0, 0x0)                                                                                      
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/core/blockchain.go:1573 +0x1ddc         
github.com/ethereumproject/go-ethereum/eth.(*ProtocolManager).insertChain(0xc420130340, 0xc42c6e2000, 0x800, 0x800, 0x1cc40c0, 0x1cc40c0, 0xc43568d440)                                                             
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/handler.go:181 +0x51                
github.com/ethereumproject/go-ethereum/eth.(*ProtocolManager).(github.com/ethereumproject/go-ethereum/eth.insertChain)-fm(0xc42c6e2000, 0x800, 0x800, 0x0, 0x0, 0x0)                                                
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/handler.go:158 +0x48                
github.com/ethereumproject/go-ethereum/eth/downloader.(*Downloader).importBlockResults(0xc42197c000, 0xc436c16000, 0x1800, 0x1800, 0x0, 0x0)                                                                        
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/downloader/downloader.go:1422 +0x17f
github.com/ethereumproject/go-ethereum/eth/downloader.(*Downloader).processFullSyncContent(0xc42197c000, 0xc428187798, 0x0)                                                                                         
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/downloader/downloader.go:1397 +0x74 
github.com/ethereumproject/go-ethereum/eth/downloader.(*Downloader).(github.com/ethereumproject/go-ethereum/eth/downloader.processFullSyncContent)-fm(0x8, 0x12205f0)                                               
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/downloader/downloader.go:550 +0x2a  
github.com/ethereumproject/go-ethereum/eth/downloader.(*Downloader).spawnSync.func1(0xc430c274e0, 0xc430caaae0, 0xc430bc1a20)                                                                                       
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/downloader/downloader.go:568 +0x51  
created by github.com/ethereumproject/go-ethereum/eth/downloader.(*Downloader).spawnSync                  
        /home/tomek/go/src/github.com/ethereumproject/go-ethereum/eth/downloader/downloader.go:568 +0xc7
```
from #585