### PR TITLE
review and proposed modifications for extended atxi api PR #598

### DIFF
--- a/core/database_util.go
+++ b/core/database_util.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"os"
 	"time"
 
 	"github.com/ethereumproject/go-ethereum/common"
@@ -299,7 +298,6 @@ func BuildAddrTxIndex(bc *BlockChain, chainDB, indexDB ethdb.Database, startInde
 	if startIndex == stopIndex {
 		// TODO(tzdybal) - return error instead of dying
 		glog.D(logger.Error).Infoln("atxi is up to date, exiting")
-		os.Exit(0)
 	}
 
 	if atxiStartBlock != uint64(math.MaxUint64) && atxiCurrentBlock < atxiStopBlock {

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -352,6 +352,7 @@ func BuildAddrTxIndex(bc *BlockChain, chainDB, indexDB ethdb.Database, startInde
 	}
 
 	if err := SetATXIBookmark(indexDB, stopIndex); err != nil {
+		// TODO(whilei) - return error instead of dying
 		glog.Fatalln(err)
 	}
 

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -337,11 +337,11 @@ func BuildAddrTxIndex(bc *BlockChain, chainDB, indexDB ethdb.Database, startInde
 		}
 		totalTxCount += uint64(txsCount)
 
-		if err := SetATXIBookmark(indexDB, i+step); err != nil {
+		atxiCurrentBlock = i + step
+		if err := SetATXIBookmark(indexDB, atxiCurrentBlock); err != nil {
 			// TODO(tzdybal) - return error instead of dying
 			glog.Fatalln(err)
 		}
-		atxiCurrentBlock = i + step
 
 		glog.D(logger.Error).Infof("atxi-build: block %d / %d txs: %d took: %v %.2f bps %.2f txps", i+step, stopIndex, txsCount, time.Since(stepStartTime).Round(time.Millisecond), float64(step)/time.Since(stepStartTime).Seconds(), float64(txsCount)/time.Since(stepStartTime).Seconds())
 		glog.V(logger.Info).Infof("atxi-build: block %d / %d txs: %d took: %v %.2f bps %.2f txps", i+step, stopIndex, txsCount, time.Since(stepStartTime).Round(time.Millisecond), float64(step)/time.Since(stepStartTime).Seconds(), float64(txsCount)/time.Since(stepStartTime).Seconds())

--- a/eth/api.go
+++ b/eth/api.go
@@ -1755,6 +1755,9 @@ func (api *PublicGethAPI) GetATXIBuildStatus() (*ATXIStatus, error) {
 
 	var status ATXIStatus
 	status.Start, status.Stop, status.Current = core.GetATXIBuildStatus()
+	if status.Start == status.Current {
+		return nil, nil
+	}
 	return &status, nil
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -1731,7 +1731,7 @@ func (api *PublicGethAPI) GetAddressTransactions(address common.Address, blockSt
 }
 
 func (api *PublicGethAPI) BuildATXI(start, stop, step uint64) (bool, error) {
-	glog.V(logger.Debug).Infoln("RPC call: debug_buildATXI %d %d %d", start, stop, step)
+	glog.V(logger.Debug).Infoln("RPC call: geth_buildATXI %d %d %d", start, stop, step)
 
 	indexDB, inUse := api.eth.BlockChain().GetAddTxIndex()
 	if !inUse {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -162,6 +162,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, null, null, null, null, null, null]
 		}),
 		new web3._extend.Method({
+			name: 'getAddressTransactions',
+			call: 'geth_getTransactionsByAddress',
+			params: 8,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, null, null, null, null, null, null]
+		}),
+		new web3._extend.Method({
 			name: 'buildATXI',
 			call: 'geth_buildATXI',
 			params: 3,


### PR DESCRIPTION
- refactor (rename variable) `blockchain.useAddTxIndex` -> `blockchain.useAddrTxIndex` (bd8f884)
- set atxi progress bookmark when `buildAtxi` is either not in use or has reached stop point (2fcbf7c)
- add alias `geth_getTransactionsByAddress` for existing `geth_getAddressTransactions` (#594)
- (02a6ceb) when `geth_getATXIBuildStatus` is called without `geth_buildATXI` having been invoked, return `"result": null` instead of 

```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "Start": 18446744073709551615,
    "Stop": 18446744073709551615,
    "Current": 18446744073709551615
  }
}
```

