### PR TITLE
log warning if unsafe use of RPC and account unlocking

### DIFF
--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -766,6 +766,9 @@ func logChainConfiguration(ctx *cli.Context, config *core.SufficientChainConfig)
 	}
 
 	glog.V(logger.Info).Info(glog.Separator("-"))
+
+	// If unsafe usage, WARNING!
+	logIfUnsafeConfiguration(ctx)
 }
 
 // MustMakeChainConfigFromDefaults reads the chain configuration from hardcode.

--- a/cmd/geth/log_context.go
+++ b/cmd/geth/log_context.go
@@ -354,9 +354,10 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 				v("*")
 				v(fmt.Sprintf(`
 
-WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
-It's unsafe to unlock an account while exposing ANY of the following RPC APIs: %s
-You can use the --%s flag to enable only certain RPC API modules if necessary.
+> WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
+> It's UNSAFE to unlock an account while exposing ANY of the following RPC APIs: %s
+> 	Anyone from the internet will be able to transfer funds from an unlocked account without any password.
+> You can use the --%s flag to enable only certain RPC API modules if necessary.
 
 `, UnlockedAccountFlag.Name, rpcapis, unsafeRPCAPIs, aliasableName(RPCApiFlag.Name, ctx)))
 				v("*")

--- a/cmd/geth/log_context.go
+++ b/cmd/geth/log_context.go
@@ -389,11 +389,13 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 				v("*")
 				v(fmt.Sprintf(`
 
-> WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
-> It's UNSAFE to unlock an account while exposing ANY of the following RPC APIs: %s to the internet.
-> 	Anyone from the internet will be able to transfer funds from an unlocked account without any password.
-> You can use the --%s flag to enable specific RPC API modules if necessary, 
-> and/or restrict the exposed RPC listen address with the --%s flag.
+>    !!!  WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].  !!!  
+> 
+>    It's UNSAFE to unlock an account while exposing ANY of the following RPC APIs: %s to the internet.
+>    Anyone from the internet will be able to transfer funds from an unlocked account without any password.
+> 
+>    You can use the --%s flag to enable specific RPC API modules if necessary, 
+>    and/or restrict the exposed RPC listen address with the --%s flag.
 
 `,
 					UnlockedAccountFlag.Name,
@@ -409,5 +411,9 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 			glog.V(logger.Warn).Warnln,
 			glog.D(logger.Warn).Warnln,
 		})
+		if !askForConfirmation("Do you really wish to proceed?") {
+			os.Exit(0)
+		}
 	}
+
 }

--- a/cmd/geth/log_context.go
+++ b/cmd/geth/log_context.go
@@ -352,9 +352,13 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 			for _, v := range vs {
 				v(glog.Separator("-"))
 				v("*")
-				v(`WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
+				v(fmt.Sprintf(`
+
+WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
 It's unsafe to unlock an account while exposing ANY of the following RPC APIs: %s
-You can use the flag --%s to enable only certain RPC API modules if necessary.`, UnlockedAccountFlag.Name, rpcapis, unsafeRPCAPIs, RPCApiFlag.Name)
+You can use the --%s flag to enable only certain RPC API modules if necessary.
+
+`, UnlockedAccountFlag.Name, rpcapis, unsafeRPCAPIs, aliasableName(RPCApiFlag.Name, ctx)))
 				v("*")
 				v(glog.Separator("-"))
 			}

--- a/cmd/geth/log_context.go
+++ b/cmd/geth/log_context.go
@@ -366,6 +366,9 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 		if configuredRPCListenAddr == "*" {
 			return true
 		}
+		if strings.Contains(configuredRPCListenAddr, "localhost") {
+			return false
+		}
 		ip := net.ParseIP(configuredRPCListenAddr)
 		for _, n := range safeRPCListenAddrsWhitelist {
 			if ok, err := discover.IpBetween(n[0], n[1], ip); ok && err == nil {
@@ -387,11 +390,18 @@ func logIfUnsafeConfiguration(ctx *cli.Context) {
 				v(fmt.Sprintf(`
 
 > WARNING: Unsafe use of --%s and exposed RPC API [ currently: %s ].
-> It's UNSAFE to unlock an account while exposing ANY of the following RPC APIs: %s
+> It's UNSAFE to unlock an account while exposing ANY of the following RPC APIs: %s to the internet.
 > 	Anyone from the internet will be able to transfer funds from an unlocked account without any password.
-> You can use the --%s flag to enable only certain RPC API modules if necessary.
+> You can use the --%s flag to enable specific RPC API modules if necessary, 
+> and/or restrict the exposed RPC listen address with the --%s flag.
 
-`, UnlockedAccountFlag.Name, rpcapis, unsafeRPCAPIs, aliasableName(RPCApiFlag.Name, ctx)))
+`,
+					UnlockedAccountFlag.Name,
+					rpcapis,
+					unsafeRPCAPIs,
+					aliasableName(RPCApiFlag.Name, ctx),
+					aliasableName(RPCListenAddrFlag.Name, ctx),
+				))
 				v("*")
 				v(glog.Separator("-"))
 			}

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -54,26 +54,26 @@ var (
 	// I expect many of these occasions will be very unlikely.
 	//
 	// IPv4
-	ipv4ReservedRangeThis               = [2]net.IP{net.ParseIP("0.0.0.0"), net.ParseIP("0.255.255.255")}
-	ipv4ReservedRangePrivateNetwork     = [2]net.IP{net.ParseIP("10.0.0.0"), net.ParseIP("10.255.255.255")}
+	Ipv4ReservedRangeThis               = [2]net.IP{net.ParseIP("0.0.0.0"), net.ParseIP("0.255.255.255")}
+	Ipv4ReservedRangePrivateNetwork     = [2]net.IP{net.ParseIP("10.0.0.0"), net.ParseIP("10.255.255.255")}
 	ipv4ReservedRangeProviderSubscriber = [2]net.IP{net.ParseIP("100.64.0.0"), net.ParseIP("100.127.255.255")}
-	ipv4ReservedRangeLoopback           = [2]net.IP{net.ParseIP("127.0.0.0"), net.ParseIP("127.255.255.255")}
-	ipv4ReservedRangeLinkLocal          = [2]net.IP{net.ParseIP("169.254.0.0"), net.ParseIP("169.254.255.255")}
-	ipv4ReservedRangeLocalPrivate1      = [2]net.IP{net.ParseIP("172.16.0.0"), net.ParseIP("172.31.255.255")}
-	ipv4ReservedRangeSpecialPurpose     = [2]net.IP{net.ParseIP("192.0.0.0"), net.ParseIP("192.0.0.255")}
-	ipv4ReservedRangeTestNet1           = [2]net.IP{net.ParseIP("192.0.2.0"), net.ParseIP("192.0.2.255")}
-	ipv4ReservedRange6to4               = [2]net.IP{net.ParseIP("192.88.99.0"), net.ParseIP("192.88.99.255")}
-	ipv4ReservedRangeLocalPrivate2      = [2]net.IP{net.ParseIP("192.168.0.0"), net.ParseIP("192.168.255.255")}
-	ipv4ReservedRangeSubnets            = [2]net.IP{net.ParseIP("198.18.0.0"), net.ParseIP("198.19.255.255")}
-	ipv4ReservedRangeTestNet2           = [2]net.IP{net.ParseIP("198.51.100.0"), net.ParseIP("198.51.100.255")}
-	ipv4ReservedRangeTestNet3           = [2]net.IP{net.ParseIP("203.0.113.0"), net.ParseIP("203.0.113.255")}
-	ipv4ReservedRangeMulticast          = [2]net.IP{net.ParseIP("224.0.0.0"), net.ParseIP("239.255.255.255")}
+	Ipv4ReservedRangeLoopback           = [2]net.IP{net.ParseIP("127.0.0.0"), net.ParseIP("127.255.255.255")}
+	ipv4ReservedRangeLinkLocal      = [2]net.IP{net.ParseIP("169.254.0.0"), net.ParseIP("169.254.255.255")}
+	ipv4ReservedRangeLocalPrivate1  = [2]net.IP{net.ParseIP("172.16.0.0"), net.ParseIP("172.31.255.255")}
+	ipv4ReservedRangeSpecialPurpose = [2]net.IP{net.ParseIP("192.0.0.0"), net.ParseIP("192.0.0.255")}
+	ipv4ReservedRangeTestNet1       = [2]net.IP{net.ParseIP("192.0.2.0"), net.ParseIP("192.0.2.255")}
+	ipv4ReservedRange6to4           = [2]net.IP{net.ParseIP("192.88.99.0"), net.ParseIP("192.88.99.255")}
+	Ipv4ReservedRangeLocalPrivate2  = [2]net.IP{net.ParseIP("192.168.0.0"), net.ParseIP("192.168.255.255")}
+	ipv4ReservedRangeSubnets        = [2]net.IP{net.ParseIP("198.18.0.0"), net.ParseIP("198.19.255.255")}
+	ipv4ReservedRangeTestNet2       = [2]net.IP{net.ParseIP("198.51.100.0"), net.ParseIP("198.51.100.255")}
+	ipv4ReservedRangeTestNet3       = [2]net.IP{net.ParseIP("203.0.113.0"), net.ParseIP("203.0.113.255")}
+	ipv4ReservedRangeMulticast      = [2]net.IP{net.ParseIP("224.0.0.0"), net.ParseIP("239.255.255.255")}
 	ipv4ReservedRangeFuture             = [2]net.IP{net.ParseIP("240.0.0.0"), net.ParseIP("255.255.255.254")}
 	ipv4ReservedRangeLimitedBroadcast   = [2]net.IP{net.ParseIP("255.255.255.255"), net.ParseIP("255.255.255.255")}
 
 	// IPv6
 	ipv6ReservedRangeUnspecified   = [2]net.IP{net.ParseIP("::"), net.ParseIP("::")}
-	ipv6ReservedRangeLoopback      = [2]net.IP{net.ParseIP("::1"), net.ParseIP("::1")}
+	Ipv6ReservedRangeLoopback      = [2]net.IP{net.ParseIP("::1"), net.ParseIP("::1")}
 	ipv6ReservedRangeDocumentation = [2]net.IP{net.ParseIP("2001:db8::"), net.ParseIP("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff")}
 	ipv6ReservedRange6to4          = [2]net.IP{net.ParseIP("2002::"), net.ParseIP("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff")}
 	ipv6ReservedRangeUniqueLocal   = [2]net.IP{net.ParseIP("fc00::"), net.ParseIP("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")}
@@ -750,16 +750,16 @@ func expired(ts uint64) bool {
 
 func isReserved(ip net.IP) bool {
 	reserved := [][2]net.IP{
-		ipv4ReservedRangeThis,
-		ipv4ReservedRangePrivateNetwork,
+		Ipv4ReservedRangeThis,
+		Ipv4ReservedRangePrivateNetwork,
 		ipv4ReservedRangeProviderSubscriber,
-		ipv4ReservedRangeLoopback,
+		Ipv4ReservedRangeLoopback,
 		ipv4ReservedRangeLinkLocal,
 		ipv4ReservedRangeLocalPrivate1,
 		ipv4ReservedRangeSpecialPurpose,
 		ipv4ReservedRangeTestNet1,
 		ipv4ReservedRange6to4,
-		ipv4ReservedRangeLocalPrivate2,
+		Ipv4ReservedRangeLocalPrivate2,
 		ipv4ReservedRangeSubnets,
 		ipv4ReservedRangeTestNet2,
 		ipv4ReservedRangeTestNet3,
@@ -767,7 +767,7 @@ func isReserved(ip net.IP) bool {
 		ipv4ReservedRangeFuture,
 		ipv4ReservedRangeLimitedBroadcast,
 		ipv6ReservedRangeUnspecified,
-		ipv6ReservedRangeLoopback,
+		Ipv6ReservedRangeLoopback,
 		ipv6ReservedRangeDocumentation,
 		ipv6ReservedRange6to4,
 		ipv6ReservedRangeUniqueLocal,


### PR DESCRIPTION
Yields:

```
$ geth --chain morden --unlock 0 --rpc
2018-05-21 13:55:27 Geth Classic version: whilei.v5.3.0+2-b4b0c9f[branch=feat/unlock-rpc-warn,commit=problem:-unsafe-usage-is-accompanied-with-a-usage-warning,built=May/21Mon-13:55:19]
2018-05-21 13:55:27 Blockchain: Morden Testnet
2018-05-21 13:55:27 Chain database: /Users/ia/Library/EthereumClassic/morden/chaindata
2018-05-21 13:55:27 Blockchain upgrades configured: 6
2018-05-21 13:55:27   494000 Homestead
2018-05-21 13:55:27  1783000 GasReprice
2018-05-21 13:55:27  1885000 The DAO Hard Fork
2018-05-21 13:55:27  1915000 Diehard
2018-05-21 13:55:27  2000000 Gotham
2018-05-21 13:55:27  2300000 Defuse Difficulty Bomb
2018-05-21 13:55:27 --------------------------------------------------------------------------------------------------------------
2018-05-21 13:55:27 *
2018-05-21 13:55:27

WARNING: Unsafe use of --unlock and exposed RPC API [ currently: eth,net,web3 ].
It's unsafe to unlock an account while exposing ANY of the following RPC APIs: [eth personal admin]
You can use the flag --rpc-api to enable only certain RPC API modules if necessary.


2018-05-21 13:55:27 *
2018-05-21 13:55:27 --------------------------------------------------------------------------------------------------------------
```