### PR TITLE
add available context info to debug log file headers

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -36,7 +35,8 @@ type ClientSessionIdentityT struct {
 
 // String is the stringer fn for ClientSessionIdentityT
 func (s *ClientSessionIdentityT) String() string {
-	return fmt.Sprint(s.Goos, s.Goarch, s.SessionID, s.Hostname, s.Username, s.MachineID, strconv.Itoa(s.Pid))
+	return fmt.Sprintf("VERSION=%s GO=%s GOOS=%s GOARCH=%s SESSIONID=%s HOSTNAME=%s USER=%s MACHINE=%s PID=%d",
+		s.Version, s.Goversion, s.Goos, s.Goarch, s.SessionID, s.Hostname, s.Username, s.MachineID, s.Pid)
 }
 
 // Helpers for random sessionid string.

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -121,6 +121,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/fatih/color"
 )
 
@@ -1159,8 +1160,8 @@ func (sb *syncBuffer) rotateCurrent(now time.Time) error {
 	// Write header.
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Log file created at: %s\n", now.Format("2006/01/02 15:04:05"))
-	fmt.Fprintf(&buf, "Running on machine: %s\n", host)
 	fmt.Fprintf(&buf, "Binary: Built with %s %s for %s/%s\n", runtime.Compiler, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&buf, "Context: %s", common.GetClientSessionIdentity().String())
 	fmt.Fprintf(&buf, "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg\n")
 	n, err := sb.file.Write(buf.Bytes())
 	sb.nbytes += uint64(n)

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -1161,7 +1161,7 @@ func (sb *syncBuffer) rotateCurrent(now time.Time) error {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Log file created at: %s\n", now.Format("2006/01/02 15:04:05"))
 	fmt.Fprintf(&buf, "Binary: Built with %s %s for %s/%s\n", runtime.Compiler, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-	fmt.Fprintf(&buf, "Context: %s", common.GetClientSessionIdentity().String())
+	fmt.Fprintf(&buf, "Context: %s\n", common.GetClientSessionIdentity().String())
 	fmt.Fprintf(&buf, "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg\n")
 	n, err := sb.file.Write(buf.Bytes())
 	sb.nbytes += uint64(n)


### PR DESCRIPTION
Since version, context, and session data is available from `common`, let's use it in debug log files to provide additional context for interpreting debug logs.

Changes this:

```
Log file created at: 2018/05/28 22:06:40
Running on machine: node-geth-500-k969c
Binary: Built with gc go1.9.4 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
```

To this:

```
Log file created at: 2018/05/29 07:15:11
Binary: Built with gc go1.9.2 for darwin/amd64
Context: VERSION=whilei.v5.3.0+22-58cea72[branch=feat/debug-log-with-version-header,commit=problem:-debug-log-files-lack-available-context-info,built=May/29Tue-07:14:48] GO=go1.9.2 GOOS=darwin GOARCH=amd64 SESSIONID=CAUt HOSTNAME=mh USER=ia MACHINE=a2c2f59f PID=18704
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
```