### PR TITLE
CI: attempt deploy steps only from main repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ deploy_steps: &deploy_steps
     - deploy:
         name: Deploy to builds.etcdevteam.com
         command: |
+          if [[ $CIRCLE_PROJECT_USERNAME != ethereumproject ]]; then echo "Deployments only enabled from ethereumproject/ repo. Exiting." && exit 0; fi
           export GOPATH=$HOME/go
           export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
           cd $GOPATH/src/github.com/ethereumproject/go-ethereum

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,19 +46,15 @@ build_script:
       .\geth.exe version | Where {$_ -match "^Version: "} | %{$actual=($_ -split "\s+")[1];If($actual -ne $env:VERSION){"Expected: `"$env:VERSION`", got: `"$ACTUAL`""; exit 1}}
   - 7z a geth-classic-win64-%VERSION%.zip geth.exe
 before_deploy:
-  - ps: >-
-      If ($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') {
-        Exit 0
-      }
   # Set up GCP upload.
-  - nuget install secure-file -ExcludeVersion
-  - secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
+  - ps: >-
+      If ($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') {
+        nuget install secure-file -ExcludeVersion
+        secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
+      }
 # Deploy on APPVEYOR_REPO_BRANCH=master or APPVEYOR_REPO_TAG=true
 deploy_script:
   - ps: >-
-      If ($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') {
-        Exit 0
-      }
-      If (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true')) {
+      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
         janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 before_deploy:
   # Set up GCP upload.
   - ps: >-
-      If (($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -ne 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
+      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
         nuget install secure-file -ExcludeVersion
         secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 before_deploy:
   # Set up GCP upload.
   - ps: >-
-      If ($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') {
+      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
         nuget install secure-file -ExcludeVersion
         secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,12 +46,19 @@ build_script:
       .\geth.exe version | Where {$_ -match "^Version: "} | %{$actual=($_ -split "\s+")[1];If($actual -ne $env:VERSION){"Expected: `"$env:VERSION`", got: `"$ACTUAL`""; exit 1}}
   - 7z a geth-classic-win64-%VERSION%.zip geth.exe
 before_deploy:
+  - ps: >-
+      If ($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') {
+        Exit 0
+      }
   # Set up GCP upload.
   - nuget install secure-file -ExcludeVersion
   - secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
 # Deploy on APPVEYOR_REPO_BRANCH=master or APPVEYOR_REPO_TAG=true
 deploy_script:
   - ps: >-
+      If ($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') {
+        Exit 0
+      }
       If (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true')) {
         janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 before_deploy:
   # Set up GCP upload.
   - ps: >-
-      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
+      If (($env:APPVEYOR_REPO_NAME -ne 'ethereumproject/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -ne 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
         nuget install secure-file -ExcludeVersion
         secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret %GCP_PASSWD% -out .gcloud.json
       }


### PR DESCRIPTION
### problem

Forked versions of this repo failed CI tests because deploy steps requiring keys and uploads would fail.

### solution

Add conditionals to CI configs specifying that deploy should only happen from this main repo.