### PR TITLE
problem: bats tests default geth cmd should not include flags

### DIFF
--- a/tests/bats/api_eth.bats
+++ b/tests/bats/api_eth.bats
@@ -1,22 +1,21 @@
 #!/usr/bin/env bats
 
 # Current build.
-: ${GETH_CMD:=$GOPATH/bin/geth --datadir $BATS_TMPDIR \
-		--lightkdf \
-		--verbosity 0 \
-		--display 0 \
-		--port 33333 \
-		--no-discover \
-		--keystore $GOPATH/src/github.com/ethereumproject/go-ethereum/accounts/testdata/keystore \
-		--unlock "f466859ead1932d743d622cb74fc058882e8648a" \
-	}
-# EF go-ethereum for comparison
-# : ${GETH_CMD:=$GOPATH/bin/mgeth --datadir $GETH_TMP_DATA_DIR --lightkdf --verbosity 0 --port 33333}
+: ${GETH_CMD:=$GOPATH/bin/geth}
+: ${GETH_OPTS:=--datadir $BATS_TMPDIR \
+               		--lightkdf \
+               		--verbosity 0 \
+               		--display 0 \
+               		--port 33333 \
+               		--no-discover \
+               		--keystore $GOPATH/src/github.com/ethereumproject/go-ethereum/accounts/testdata/keystore \
+               		--unlock "f466859ead1932d743d622cb74fc058882e8648a" \
+    }
 
 setup() {
 	# GETH_TMP_DATA_DIR=`mktemp -d`
 	# mkdir "$BATS_TMPDIR/mainnet"
-  testacc=f466859ead1932d743d622cb74fc058882e8648a
+    testacc=f466859ead1932d743d622cb74fc058882e8648a
 	tesetacc_pass=foobar
 	regex_signature_success='0x[0-9a-f]{130}'
 }
@@ -25,7 +24,7 @@ setup() {
 # }
 
 @test "eth_sign1" {
-		run $GETH_CMD \
+		run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="eth.sign('"$testacc"', '"$d"');" console 2> /dev/null
 		echo "$output"
@@ -34,7 +33,7 @@ setup() {
 }
 
 @test "eth_sign2" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="eth.sign('"$testacc"', web3.fromAscii('Schoolbus'));" console 2> /dev/null
 		echo "$output"

--- a/tests/bats/api_personal.bats
+++ b/tests/bats/api_personal.bats
@@ -1,22 +1,21 @@
 #!/usr/bin/env bats
 
 # Current build.
-: ${GETH_CMD:=$GOPATH/bin/geth --datadir $BATS_TMPDIR \
-		--lightkdf \
-		--verbosity 0 \
-		--display 0 \
-		--port 33333 \
-		--no-discover \
-		--keystore $GOPATH/src/github.com/ethereumproject/go-ethereum/accounts/testdata/keystore \
-		--unlock "f466859ead1932d743d622cb74fc058882e8648a" \
-	}
-# EF go-ethereum for comparison
-# : ${GETH_CMD:=$GOPATH/bin/mgeth --datadir $GETH_TMP_DATA_DIR --lightkdf --verbosity 0 --port 33333}
+: ${GETH_CMD:=$GOPATH/bin/geth}
+: ${GETH_OPTS:=--datadir $BATS_TMPDIR \
+               		--lightkdf \
+               		--verbosity 0 \
+               		--display 0 \
+               		--port 33333 \
+               		--no-discover \
+               		--keystore $GOPATH/src/github.com/ethereumproject/go-ethereum/accounts/testdata/keystore \
+               		--unlock "f466859ead1932d743d622cb74fc058882e8648a" \
+    }
 
 setup() {
 	# GETH_TMP_DATA_DIR=`mktemp -d`
 	# mkdir "$BATS_TMPDIR/mainnet"
-  testacc=f466859ead1932d743d622cb74fc058882e8648a
+    testacc=f466859ead1932d743d622cb74fc058882e8648a
 	tesetacc_pass=foobar
 	regex_signature_success='0x[0-9a-f]{130}'
 }
@@ -25,7 +24,7 @@ setup() {
 # }
 
 @test "personal_sign1" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="personal.sign('0xdeadbeef', '"$testacc"', '"$tesetacc_pass"');" console 2> /dev/null
 		echo "$output"
@@ -34,7 +33,7 @@ setup() {
 }
 
 @test "personal_sign2" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="personal.sign(web3.fromAscii('Schoolbus'), '"$testacc"', '"$tesetacc_pass"');" console 2> /dev/null
 		echo "$output"
@@ -43,7 +42,7 @@ setup() {
 }
 
 @test "personal_listAccounts" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="personal.listAccounts;" console 2> /dev/null
 		echo "$output"
@@ -52,7 +51,7 @@ setup() {
 }
 
 @test "personal_lockAccount" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="personal.lockAccount('"$testacc"');" console 2> /dev/null
 		echo "$output"
@@ -61,7 +60,7 @@ setup() {
 }
 
 @test "personal_unlockAccount" {
-    run $GETH_CMD \
+    run $GETH_CMD $GETH_OPTS \
 				--password=<(echo $tesetacc_pass) \
         --exec="personal.lockAccount('"$testacc"') && personal.unlockAccount('"$testacc"', '"$tesetacc_pass"', 0);" console 2> /dev/null
 		echo "$output"


### PR DESCRIPTION
solution: separate cmd and flag default env vars

This makes the bats tests more extensible by actually allowing `env GETH_CMD` to be set (`: ${FOO:=bar}` sets defaults)