### PR TITLE
Fix/rpc block mixhash

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -849,6 +849,7 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 		"hash":             b.Hash(),
 		"parentHash":       b.ParentHash(),
 		"nonce":            b.Header().Nonce,
+		"mixHash":          b.Header().MixDigest,
 		"sha3Uncles":       b.UncleHash(),
 		"logsBloom":        b.Bloom(),
 		"stateRoot":        b.Root(),

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1581,8 +1581,8 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 	// Retrieve the a batch of results to import
 	first, last := results[0].Header, results[len(results)-1].Header
 	glog.V(logger.Debug).Infoln("Inserting fast-sync blocks", "items", len(results),
-		"firstnum", first.Number, "firsthash", first.Hash(),
-		"lastnumn", last.Number, "lasthash", last.Hash(),
+		"firstnum", first.Number, "firsthash", first.Hash().Hex(),
+		"lastnumn", last.Number, "lasthash", last.Hash().Hex(),
 	)
 	blocks := make([]*types.Block, len(results))
 	receipts := make([]types.Receipts, len(results))


### PR DESCRIPTION
```js
> eth.getBlock("latest");
{
  difficulty: 163634690461513,
  extraData: "0x457468657265756d436c6173736963534f4c4f2f326d696e6572735f555341",
  gasLimit: 4731153,
  gasUsed: 63160,
  hash: "0xb822d4c2cab56f07821af876cef4b2a59d161029a76224d89e1aede6b0519364",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0x004730417cd2b1d19f6be2679906ded4fa8a64e2",
  mixHash: "0xb83c2272fabd0a6400d17f798d4732a2ce30edc18f94cd8c26f480876c67533e",
  nonce: "0x5eaaf41803bc2412",
  number: 6124631,
  parentHash: "0xc44453df7d7e0cde81bcdbae4f64b859166ecb95999d697c553b82528aff9f82",
  receiptsRoot: "0x321b3ea5418fbd8cb9e63328eca9ae845fdc7c3131b1949ad327ec1f71f5e769",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 935,
  stateRoot: "0x23c42f29c421b9688027764a235da21598d055c90673d963484ee3d4d771e8dc",
  timestamp: 1530803545,
  totalDifficulty: 335578983877232315465,
  transactions: ["0x776f81991c5be5f555d68dbebadd3816626770de1c7743013936e7df0f435888", "0x27ee82820a5400876d9ab5d9d6ae1957e46948fa9cb4acd7dc75ee7c19f8e4ff", "0x8c383727840364a115972bf58ec5ae4fa437574faa187f4775c3c33052904933"],
  transactionsRoot: "0xd9304f59f6a51f503cc3b31e7dcf606473d8b02d91a01c805008886d2156d742",
  uncles: []
}
```

Note related issue and links at #640.