### PR TITLE
make sputnikvm enable-able via go link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ workflows:
               only: /.*/
       - mac_evm_unit_tests:
           requires:
-            - mac_sputnik_vm
+            - mac_env_setup
           filters:
             tags:
               only: /.*/
@@ -302,7 +302,7 @@ workflows:
               only: /.*/
       - linux_unit_tests:
           requires:
-            - linux_sputnik_vm
+            - linux_env_setup
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,13 @@ unit_tests_steps: &unit_tests_steps
           export GOPATH=$HOME/go
           export GOBIN=$GOPATH/bin
           export PATH=$PATH:$GOBIN
-          export CGO_LDFLAGS="$GOPATH/src/github.com/ethereumproject/go-ethereum/vendor/github.com/ethereumproject/sputnikvm-ffi/c/libsputnikvm.a -ldl"
-          if [ "$(uname)" == "Darwin" ]; then
-            export CGO_LDFLAGS="$CGO_LDFLAGS -lresolv"
+          export TAGS="netgo deterministic"
+          if [ $USE_SPUTNIK_VM == true ]; then
+            export CGO_LDFLAGS="$GOPATH/src/github.com/ethereumproject/go-ethereum/vendor/github.com/ethereumproject/sputnikvm-ffi/c/libsputnikvm.a -ldl"
+            if [ "$(uname)" == "Darwin" ]; then
+              export CGO_LDFLAGS="$CGO_LDFLAGS -lresolv"
+            fi
+            export TAGS="sputnikvm $TAGS"
           fi
           export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
           cd $GOPATH/src/github.com/ethereumproject/go-ethereum
@@ -57,8 +61,7 @@ unit_tests_steps: &unit_tests_steps
           # Since core/ and tests/ packages are run deterministically, we can safely
           # infer that SputnikVM is functioning the same as the native VM without running
           # the schroedinger nondeterministic tests with sputnik enabled.
-          go test -tags="netgo deterministic" ./...
-          go test -ldflags "-X github.com/ethereumproject/go-ethereum/core.UseSputnikVM=true" -tags="sputnikvm netgo deterministic" ./...
+          go test -ldflags "-X github.com/ethereumproject/go-ethereum/core.UseSputnikVM=$USE_SPUTNIK_VM" -tags="$TAGS" ./...
           schroedinger -t 5 -f ./schroedinger-tests.txt
 
 bats_tests_steps: &bats_tests_steps
@@ -192,16 +195,34 @@ jobs:
       - image: circleci/golang:1.9
     <<: *sputnik_vm_steps
 
-  mac_unit_tests:
+  mac_evm_unit_tests:
     macos:
       xcode: "9.0"
+    environment:
+        USE_SPUTNIK_VM: false
     <<: *unit_tests_steps
 
-  linux_unit_tests:
+  linux_evm_unit_tests:
     docker:
       - image: circleci/golang:1.9
-        environment:
-            GOMAXPROCS: 2
+    environment:
+        GOMAXPROCS: 2
+        USE_SPUTNIK_VM: false
+    <<: *unit_tests_steps
+
+  mac_sputnikvm_unit_tests:
+    macos:
+      xcode: "9.0"
+    environment:
+        USE_SPUTNIK_VM: true
+    <<: *unit_tests_steps
+
+  linux_sputnikvm_unit_tests:
+    docker:
+      - image: circleci/golang:1.9
+    environment:
+        GOMAXPROCS: 2
+        USE_SPUTNIK_VM: true
     <<: *unit_tests_steps
 
   mac_bats_tests:
@@ -238,7 +259,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - mac_unit_tests:
+      - mac_evm_unit_tests:
+          requires:
+            - mac_sputnik_vm
+          filters:
+            tags:
+              only: /.*/
+      - mac_sputnikvm_unit_tests:
           requires:
             - mac_sputnik_vm
           filters:
@@ -252,7 +279,8 @@ workflows:
               only: /.*/
       - mac_deploy:
           requires:
-            - mac_unit_tests
+            - mac_evm_unit_tests
+            - mac_sputnikvm_unit_tests
             - mac_bats_tests
           filters:
             branches:
@@ -286,7 +314,8 @@ workflows:
               only: /.*/
       - linux_deploy:
           requires:
-            - linux_unit_tests
+            - linux_evm_unit_tests
+            - linux_sputnikvm_unit_tests
             - linux_bats_tests
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,9 +300,15 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - linux_unit_tests:
+      - linux_evm_unit_tests:
           requires:
             - linux_env_setup
+          filters:
+            tags:
+              only: /.*/
+      - linux_sputnikvm_unit_tests:
+          requires:
+            - linux_sputnik_vm
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,11 @@ unit_tests_steps: &unit_tests_steps
           export PATH=$PATH:$HOME/.cargo/bin:$HOME/janusbin
           cd $GOPATH/src/github.com/ethereumproject/go-ethereum
           go env
-          go test -tags="sputnikvm netgo deterministic" ./...
+          # Since core/ and tests/ packages are run deterministically, we can safely
+          # infer that SputnikVM is functioning the same as the native VM without running
+          # the schroedinger nondeterministic tests with sputnik enabled.
+          go test -tags="netgo deterministic" ./...
+          go test -ldflags "-X github.com/ethereumproject/go-ethereum/core.UseSputnikVM=true" -tags="sputnikvm netgo deterministic" ./...
           schroedinger -t 5 -f ./schroedinger-tests.txt
 
 bats_tests_steps: &bats_tests_steps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,9 @@ install:
   - go env
   - go get golang.org/x/sys/windows
 build_script:
-  - go test -tags="sputnikvm deterministic" ./...
+  # See .circleci/config.yml for explanation about SputnikVM nondeterministic tests absence.
+  - go test -tags="deterministic" ./...
+  - go test -ldflags "-X github.com/ethereumproject/go-ethereum/core.UseSputnikVM=true" -tags="sputnikvm deterministic" ./...
   - schroedinger.exe -t 5 -f .\schroedinger-tests.txt
   - go build -tags=sputnikvm -ldflags "-X main.Version=%VERSION%" github.com/ethereumproject/go-ethereum/cmd/geth
   - ps: >-

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -253,7 +253,7 @@ func makeCLIApp() (app *cli.App) {
 
 		if ctx.IsSet(SputnikVMFlag.Name) {
 			if core.SputnikVMExists {
-				core.UseSputnikVM = true
+				core.UseSputnikVM = "true"
 			} else {
 				log.Fatal("This version of geth wasn't built to include SputnikVM. To build with SputnikVM, use -tags=sputnikvm following the go build command.")
 			}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1422,7 +1422,7 @@ func TestLogReorgs(t *testing.T) {
 	// not contain a patch for this. As a result, it cannot figure out
 	// a correct patch to run. So we bypass this test when running
 	// with `UseSputnikVM`.
-	if UseSputnikVM {
+	if UseSputnikVM == "true" {
 		return
 	}
 
@@ -1484,7 +1484,7 @@ func TestReorgSideEvent(t *testing.T) {
 	// not contain a patch for this. As a result, it cannot figure out
 	// a correct patch to run. So we bypass this test when running
 	// with `UseSputnikVM`.
-	if UseSputnikVM {
+	if UseSputnikVM == "true" {
 		return
 	}
 

--- a/core/multivm_fake_processor.go
+++ b/core/multivm_fake_processor.go
@@ -12,7 +12,7 @@ import (
 
 const SputnikVMExists = false
 
-var UseSputnikVM = false
+var UseSputnikVM = "false"
 
 func ApplyMultiVmTransaction(config *ChainConfig, bc *BlockChain, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, totalUsedGas *big.Int) (*types.Receipt, evm.Logs, *big.Int, error) {
 	panic("not implemented")

--- a/core/multivm_processor.go
+++ b/core/multivm_processor.go
@@ -17,7 +17,10 @@ import (
 
 const SputnikVMExists = true
 
-var UseSputnikVM = false
+// UseSputnikVM determines whether the VM will be Sputnik or Geth's native one.
+// Awkward though it is to use a string variable, go's -ldflags relies on it being a constant string in order to be settable via -X from the command line,
+// eg. -ldflags "-X core.UseSputnikVM=true".
+var UseSputnikVM string = "false"
 
 // Apply a transaction using the SputnikVM processor with the given
 // chain config and state. Note that we use the name of the chain

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -84,7 +84,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB) (ty
 			}
 		}
 		statedb.StartRecord(tx.Hash(), block.Hash(), i)
-		if !UseSputnikVM {
+		if UseSputnikVM != "true" {
 			receipt, logs, _, err := ApplyTransaction(p.config, p.bc, gp, statedb, header, tx, totalUsedGas)
 			if err != nil {
 				return nil, nil, totalUsedGas, err

--- a/tests/init.go
+++ b/tests/init.go
@@ -49,7 +49,7 @@ var (
 )
 
 func initBlockSkipTests() []string {
-	if core.UseSputnikVM {
+	if core.UseSputnikVM == "true" {
 		return []string{
 			// These tests are not valid, as they are out of scope for RLP and
 			// the consensus protocol.


### PR DESCRIPTION
This enables running tests and any other go commands outside of application CLI usage with or without(default) SputnikVM instead of the native geth VM.

@mersinvald, your review encouraged too. (Don't know why can't request official for you... maybe you still need to be added to ethereumproject/?)