### PR TITLE
fix linter warnings

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1329,7 +1329,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			// Store the addr-tx indexes if enabled
 			if bc.atxi != nil {
 				if err := WriteBlockAddTxIndexes(bc.atxi.Db, block); err != nil {
-					glog.Fatalf("failed to write block add-tx indexes", err)
+					glog.Fatalf("failed to write block add-tx indexes, err: %v", err)
 				}
 				// if buildATXI has been in use (via RPC) and is NOT finished, current < stop
 				// if buildATXI has been in use (via RPC) and IS finished, current == stop
@@ -1539,7 +1539,7 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (res *ChainInsertResult) {
 	for i := 1; i < len(chain); i++ {
 		if chain[i].NumberU64() != chain[i-1].NumberU64()+1 || chain[i].ParentHash() != chain[i-1].Hash() {
 			// Chain broke ancestry, log a messge (programming error) and skip insertion
-			glog.V(logger.Error).Infof("Non contiguous block insert", "number", chain[i].Number(), "hash", chain[i].Hash(),
+			glog.V(logger.Error).Infoln("Non contiguous block insert", "number", chain[i].Number(), "hash", chain[i].Hash(),
 				"parent", chain[i].ParentHash(), "prevnumber", chain[i-1].Number(), "prevhash", chain[i-1].Hash())
 
 			res.Error = fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, chain[i-1].NumberU64(),

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -127,12 +127,12 @@ func (pool *TxPool) eventLoop() {
 func (pool *TxPool) resetState() {
 	currentState, err := pool.currentState()
 	if err != nil {
-		glog.V(logger.Info).Infoln("failed to get current state: %v", err)
+		glog.V(logger.Info).Infof("failed to get current state: %v", err)
 		return
 	}
 	managedState := state.ManageState(currentState)
 	if err != nil {
-		glog.V(logger.Info).Infoln("failed to get managed state: %v", err)
+		glog.V(logger.Info).Infof("failed to get managed state: %v", err)
 		return
 	}
 	pool.pendingState = managedState
@@ -333,7 +333,7 @@ func (self *TxPool) add(tx *types.Transaction) error {
 		).Send(mlogTxPool)
 	}
 	if glog.V(logger.Debug) {
-		glog.Infof("(t) %x => %s (%v) %x\n", from, toName, tx.Value, hash)
+		glog.Infof("(t) %x => %s (%v) %x\n", from, toName, tx.Value(), hash)
 	}
 
 	return nil
@@ -557,7 +557,7 @@ func (pool *TxPool) checkQueue() {
 func (pool *TxPool) validatePool() {
 	state, err := pool.currentState()
 	if err != nil {
-		glog.V(logger.Info).Infoln("failed to get current state: %v", err)
+		glog.V(logger.Info).Infof("failed to get current state: %v", err)
 		return
 	}
 	balanceCache := make(map[common.Address]*big.Int)

--- a/eth/api.go
+++ b/eth/api.go
@@ -718,7 +718,7 @@ func (s *PublicBlockChainAPI) NewBlocks(ctx context.Context, args NewBlocksArgs)
 		if err == nil {
 			return subscription.Notify(notification)
 		}
-		glog.V(logger.Warn).Info("unable to format block %v\n", err)
+		glog.V(logger.Warn).Infof("unable to format block %v\n", err)
 		return nil
 	}
 	s.muNewBlockSubscriptions.Unlock()
@@ -1742,7 +1742,7 @@ func (api *PublicGethAPI) GetTransactionsByAddress(address common.Address, block
 // Optional values include start and stop block numbers, and to/from/both value for tx/address relation.
 // Returns a slice of strings of transactions hashes.
 func (api *PublicGethAPI) GetAddressTransactions(address common.Address, blockStartN uint64, blockEndN rpc.BlockNumber, toOrFrom string, txKindOf string, pagStart, pagEnd int, reverse bool) (list []string, err error) {
-	glog.V(logger.Debug).Infoln("RPC call: debug_getAddressTransactions %s %d %d %s %s", address, blockStartN, blockEndN, toOrFrom, txKindOf)
+	glog.V(logger.Debug).Infof("RPC call: debug_getAddressTransactions %s %d %d %s %s", address, blockStartN, blockEndN, toOrFrom, txKindOf)
 
 	atxi := api.eth.BlockChain().GetAtxi()
 	if atxi == nil {
@@ -1777,7 +1777,7 @@ func (api *PublicGethAPI) GetAddressTransactions(address common.Address, blockSt
 }
 
 func (api *PublicGethAPI) BuildATXI(start, stop, step rpc.BlockNumber) (bool, error) {
-	glog.V(logger.Debug).Infoln("RPC call: geth_buildATXI %v %v %v", start, stop, step)
+	glog.V(logger.Debug).Infof("RPC call: geth_buildATXI %v %v %v", start, stop, step)
 
 	convert := func(number rpc.BlockNumber) uint64 {
 		switch number {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -893,7 +893,7 @@ func (d *Downloader) fetchHeaders(p *peer, from uint64, pivot uint64) error {
 		case packet := <-d.headerCh:
 			// Make sure the active peer is giving us the skeleton headers
 			if packet.PeerId() != p.id {
-				glog.V(logger.Debug).Warnf("Received skeleton from incorrect peer", "peer", packet.PeerId())
+				glog.V(logger.Debug).Warnln("Received skeleton from incorrect peer", "peer", packet.PeerId())
 				break
 			}
 			metrics.DLHeaderTimer.UpdateSince(request)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -341,7 +341,7 @@ func (d *Downloader) RegisterPeer(id string, version int, name string, currentHe
 	glog.V(logger.Detail).Infoln("Registering peer", id)
 	err = d.peers.Register(newPeer(id, version, name, currentHead, getRelHeaders, getAbsHeaders, getBlockBodies, getReceipts, getNodeData))
 	if err != nil {
-		glog.V(logger.Error).Errorf("Register failed:", err)
+		glog.V(logger.Error).Errorf("Register failed, err: %v", err)
 		return err
 	}
 	d.qosReduceConfidence()
@@ -404,7 +404,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 		d.dropPeer(id)
 
 	default:
-		glog.V(logger.Core).Warnln("Peer %s: sync: %s", id, err)
+		glog.V(logger.Core).Warnf("Peer %s: sync: %s", id, err)
 	}
 	return err
 }
@@ -675,7 +675,7 @@ func (d *Downloader) fetchHeight(p *peer) (*types.Header, error) {
 			return headers[0], nil
 
 		case <-timer.C:
-			glog.V(logger.Debug).Infof("%v: head header timeout", p, ttl)
+			glog.V(logger.Debug).Infof("%v: head header timeout, ttl: %v", p, ttl)
 			return nil, errTimeout
 
 		case <-d.bodyCh:
@@ -875,10 +875,10 @@ func (d *Downloader) fetchHeaders(p *peer, from uint64, pivot uint64) error {
 		timeout.Reset(ttl)
 
 		if skeleton {
-			glog.V(logger.Detail).Infof("Fetching skeleton headers", "count", MaxHeaderFetch, "from", from)
+			glog.V(logger.Detail).Infof("Fetching skeleton headers, count=%v from=%v", MaxHeaderFetch, from)
 			go p.getAbsHeaders(from+uint64(MaxHeaderFetch)-1, MaxSkeletonSize, MaxHeaderFetch-1, false)
 		} else {
-			glog.V(logger.Detail).Infof("Fetching full headers", "count", MaxHeaderFetch, "from", from)
+			glog.V(logger.Detail).Infof("Fetching full headers, count=%v from=%v", MaxHeaderFetch, from)
 			go p.getAbsHeaders(from, MaxHeaderFetch, 0, false)
 		}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -171,8 +171,8 @@ func NewProtocolManager(config *core.ChainConfig, mode downloader.SyncMode, netw
 	}
 	inserter := func(blocks types.Blocks) *core.ChainInsertResult {
 		if atomic.LoadUint32(&manager.fastSync) == 1 {
-			glog.V(logger.Warn).Warnf("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash().Hex()[:9])
-			glog.D(logger.Warn).Warnf("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash().Hex()[:9])
+			glog.V(logger.Warn).Warnln("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash().Hex()[:9])
+			glog.D(logger.Warn).Warnln("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash().Hex()[:9])
 		}
 		// Mark initial sync done on any fetcher import
 		atomic.StoreUint32(&manager.acceptsTxs, 1)


### PR DESCRIPTION
This fixes some log-line formatting directive linter warnings that showed up in [an Appveyor build](https://ci.appveyor.com/project/splix/go-ethereum/build/1.0.2174) for some reason.

