### PR TITLE
problem: v,r,s tx values not included in RPC Tx

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -915,6 +915,9 @@ type RPCTransaction struct {
 	Value            *rpc.HexNumber  `json:"value"`
 	ReplayProtected  bool            `json:"replayProtected"`
 	ChainId          *big.Int        `json:"chainId,omitempty"`
+	V                *rpc.HexNumber  `json:"v"`
+	R                *rpc.HexNumber  `json:"r"`
+	S                *rpc.HexNumber  `json:"s"`
 }
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
@@ -956,6 +959,8 @@ func newRPCTransactionFromBlockIndex(b *types.Block, txIndex int) (*RPCTransacti
 		}
 		from, _ := types.Sender(signer, tx)
 
+		v, r, s := tx.RawSignatureValues()
+
 		return &RPCTransaction{
 			BlockHash:        b.Hash(),
 			BlockNumber:      rpc.NewHexNumber(b.Number()),
@@ -970,6 +975,9 @@ func newRPCTransactionFromBlockIndex(b *types.Block, txIndex int) (*RPCTransacti
 			Value:            rpc.NewHexNumber(tx.Value()),
 			ReplayProtected:  protected,
 			ChainId:          chainId,
+			V:                rpc.NewHexNumber(v),
+			R:                rpc.NewHexNumber(r),
+			S:                rpc.NewHexNumber(s),
 		}, nil
 	}
 


### PR DESCRIPTION
solution: include them

Fixes #684 

Yields:

__js console__:
```js
> t = eth.getTransaction(eth.getBlock(1900000).transactions[0]);
{
  blockHash: "0x50189378a8b859a37ae92c5fb065aa1a358417bca9a051e96e1e092077ab1bd0",
  blockNumber: 1900000,
  from: "0x24ec54a7264311aa4bae55d0d7cf5965904eea20",
  gas: 30000,
  gasPrice: 20000000000,
  hash: "0x88896c85c5f2b19495bda26d7646b4a55422c7373b2a7c0760009898a9d5a54f",
  input: "0x",
  nonce: 28,
  r: "0x2983d720ad5d34086fe9d96df8e0381cf798039797b16faabfd197127c72fa14",
  replayProtected: false,
  s: "0x468f51648528c26b4344b69135341b556558f1a11db5813af10444cd316976e9",
  to: "0x544d3a4a5f643aebd3cd4a481f6bbe970ff59a8e",
  transactionIndex: 0,
  v: "0x1c",
  value: 13180300000000000000
}
```

__json rpc__:
```json
{
  "blockHash": "0x50189378a8b859a37ae92c5fb065aa1a358417bca9a051e96e1e092077ab1bd0",
  "blockNumber": "0x1cfde0",
  "from": "0x24ec54a7264311aa4bae55d0d7cf5965904eea20",
  "gas": "0x7530",
  "gasPrice": "0x4a817c800",
  "hash": "0x88896c85c5f2b19495bda26d7646b4a55422c7373b2a7c0760009898a9d5a54f",
  "input": "0x",
  "nonce": "0x1c",
  "r": "0x2983d720ad5d34086fe9d96df8e0381cf798039797b16faabfd197127c72fa14",
  "replayProtected": false,
  "s": "0x468f51648528c26b4344b69135341b556558f1a11db5813af10444cd316976e9",
  "to": "0x544d3a4a5f643aebd3cd4a481f6bbe970ff59a8e",
  "transactionIndex": "0x0",
  "v": "0x1c",
  "value": "0xb6e9d5048d14c000"
}
```

- Checked VRS vals against: https://api.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=0x88896c85c5f2b19495bda26d7646b4a55422c7373b2a7c0760009898a9d5a54f&apikey=YOURKEYHERE, where I got matching:

```json
{
"jsonrpc": "2.0",
"id": 1,
"result": {
"blockHash": "0x50189378a8b859a37ae92c5fb065aa1a358417bca9a051e96e1e092077ab1bd0",
"blockNumber": "0x1cfde0",
"from": "0x24ec54a7264311aa4bae55d0d7cf5965904eea20",
"gas": "0x7530",
"gasPrice": "0x4a817c800",
"hash": "0x88896c85c5f2b19495bda26d7646b4a55422c7373b2a7c0760009898a9d5a54f",
"input": "0x",
"nonce": "0x1c",
"to": "0x544d3a4a5f643aebd3cd4a481f6bbe970ff59a8e",
"transactionIndex": "0x0",
"value": "0xb6e9d5048d14c000",
"v": "0x1c",
"r": "0x2983d720ad5d34086fe9d96df8e0381cf798039797b16faabfd197127c72fa14",
"s": "0x468f51648528c26b4344b69135341b556558f1a11db5813af10444cd316976e9"
}
}
```