### PR TITLE
Fix/appveyor sputnikvm ffi

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - cd c:\gopath\src\github.com\ETCDEVTeam
   - git clone https://github.com/ETCDEVTeam/sputnikvm-ffi
   - cd c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
-  - cargo build --release
+  - cargo build --release --verbose
   - copy c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi\target\release\sputnikvm_ffi.lib c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib
   - set CGO_LDFLAGS=-Wl,--allow-multiple-definition c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib -lws2_32 -luserenv
   - cd c:\gopath\src\github.com\ethereumproject\go-ethereum

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,14 +24,13 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustup update
 
-  # - cd c:\gopath\src\github.com\ETCDEVTeam
-  # - git clone https://github.com/ETCDEVTeam/sputnikvm-ffi
-  # - cd c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
+  # Build sputnikvm-ffi from go-ethereum/vendor dir (depend on 'dep' vendoring version control, instead of 'upstream master' vc).
   - cd c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
   - cargo build --release --verbose
-  # Copy to both source and vendor dirs... b/c not sure ATM which one is used for building... hopefully vendor.
   - copy c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi\target\release\sputnikvm_ffi.lib c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib
+  # Set build flag definitions.
   - set CGO_LDFLAGS=-Wl,--allow-multiple-definition c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib -lws2_32 -luserenv
+
   - cd c:\gopath\src\github.com\ethereumproject\go-ethereum
 
   - echo %VERSION_BASE% %VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,14 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustup update
 
-  - cd c:\gopath\src\github.com\ETCDEVTeam
-  - git clone https://github.com/ETCDEVTeam/sputnikvm-ffi
-  - cd c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
+  # - cd c:\gopath\src\github.com\ETCDEVTeam
+  # - git clone https://github.com/ETCDEVTeam/sputnikvm-ffi
+  # - cd c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
+  - cd c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi
   - cargo build --release --verbose
-  - copy c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi\target\release\sputnikvm_ffi.lib c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib
-  - set CGO_LDFLAGS=-Wl,--allow-multiple-definition c:\gopath\src\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib -lws2_32 -luserenv
+  # Copy to both source and vendor dirs... b/c not sure ATM which one is used for building... hopefully vendor.
+  - copy c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\ffi\target\release\sputnikvm_ffi.lib c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib
+  - set CGO_LDFLAGS=-Wl,--allow-multiple-definition c:\gopath\src\github.com\ethereumproject\go-ethereum\vendor\github.com\ETCDEVTeam\sputnikvm-ffi\c\sputnikvm.lib -lws2_32 -luserenv
   - cd c:\gopath\src\github.com\ethereumproject\go-ethereum
 
   - echo %VERSION_BASE% %VERSION%


### PR DESCRIPTION
problem: Windows builds failing on master b/c `sputnikvm-ffi` not able to compile. Likely related to issues around #675 .  

solution here: Build from w/in `vendor/` dir instead of `go/.../ETCDEVTeam/sputnikvm-ffi/` to allow build to be determined by `dep` version control instead of sputnikvm-ffi master. 