### PR TITLE
Force full sync after starting fast sync

### DIFF
--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -378,7 +378,7 @@ func formatEthConfigPretty(ethConfig *eth.Config) (s []string) {
 	// NetworkID
 	ss = append(ss, printable{0, "Network", ethConfig.NetworkId})
 	// FastSync?
-	ss = append(ss, printable{0, "Fast sync", ethConfig.FastSync})
+	ss = append(ss, printable{0, "Fast sync", ethConfig.SyncMode})
 	// BlockChainVersion
 	ss = append(ss, printable{0, "Blockchain version", ethConfig.BlockChainVersion})
 	// DatabaseCache

--- a/cmd/geth/flag.go
+++ b/cmd/geth/flag.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/core/types"
 	"github.com/ethereumproject/go-ethereum/crypto"
 	"github.com/ethereumproject/go-ethereum/eth"
+	"github.com/ethereumproject/go-ethereum/eth/downloader"
 	"github.com/ethereumproject/go-ethereum/ethdb"
 	"github.com/ethereumproject/go-ethereum/event"
 	"github.com/ethereumproject/go-ethereum/logger"
@@ -591,7 +592,6 @@ func mustMakeEthConf(ctx *cli.Context, sconf *core.SufficientChainConfig) *eth.C
 		ChainConfig:             sconf.ChainConfig,
 		Genesis:                 sconf.Genesis,
 		UseAddrTxIndex:          ctx.GlobalBool(aliasableName(AddrTxIndexFlag.Name, ctx)),
-		FastSync:                ctx.GlobalBool(aliasableName(FastSyncFlag.Name, ctx)),
 		BlockChainVersion:       ctx.GlobalInt(aliasableName(BlockchainVersionFlag.Name, ctx)),
 		DatabaseCache:           ctx.GlobalInt(aliasableName(CacheFlag.Name, ctx)),
 		DatabaseHandles:         MakeDatabaseHandles(),
@@ -611,6 +611,13 @@ func mustMakeEthConf(ctx *cli.Context, sconf *core.SufficientChainConfig) *eth.C
 		GpobaseCorrectionFactor: ctx.GlobalInt(aliasableName(GpobaseCorrectionFactorFlag.Name, ctx)),
 		SolcPath:                ctx.GlobalString(aliasableName(SolcPathFlag.Name, ctx)),
 		AutoDAG:                 ctx.GlobalBool(aliasableName(AutoDAGFlag.Name, ctx)) || ctx.GlobalBool(aliasableName(MiningEnabledFlag.Name, ctx)),
+	}
+
+	if ctx.GlobalBool(aliasableName(FastSyncFlag.Name, ctx)) {
+		ethConf.SyncMode = downloader.FastSync
+	}
+	if ctx.GlobalBool(aliasableName(SlowSyncFlag.Name, ctx)) {
+		ethConf.SyncMode = downloader.ForceFullSync
 	}
 
 	if _, ok := ethConf.GasPrice.SetString(ctx.GlobalString(aliasableName(GasPriceFlag.Name, ctx)), 0); !ok {

--- a/cmd/geth/flags.go
+++ b/cmd/geth/flags.go
@@ -94,6 +94,10 @@ var (
 		Name:  "fast",
 		Usage: "Enable fast syncing through state downloads",
 	}
+	SlowSyncFlag = cli.BoolFlag{
+		Name:  "slow",
+		Usage: "Force full sync, even if fast sync is in progress",
+	}
 	LightKDFFlag = cli.BoolFlag{
 		Name:  "light-kdf,lightkdf",
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -153,6 +153,7 @@ func makeCLIApp() (app *cli.App) {
 		ChainIdentityFlag,
 		BlockchainVersionFlag,
 		FastSyncFlag,
+		SlowSyncFlag,
 		AddrTxIndexFlag,
 		AddrTxIndexAutoBuildFlag,
 		CacheFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -77,6 +77,7 @@ var AppHelpFlagAndCommandGroups = []flagGroup{
 			DevModeFlag,
 			NodeNameFlag,
 			FastSyncFlag,
+			SlowSyncFlag,
 			CacheFlag,
 			LightKDFFlag,
 			SputnikVMFlag,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -62,7 +62,7 @@ type Config struct {
 
 	NetworkId int // Network ID to use for selecting peers to connect to
 	Genesis   *core.GenesisDump
-	FastSync  bool // Enables the state download based fast synchronisation algorithm
+	SyncMode  downloader.SyncMode // Enables the state download based fast synchronisation algorithm
 	MaxPeers  int
 
 	BlockChainVersion  int
@@ -299,11 +299,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	newPool := core.NewTxPool(eth.chainConfig, eth.EventMux(), eth.blockchain.State, eth.blockchain.GasLimit)
 	eth.txPool = newPool
 
-	m := downloader.FullSync
-	if config.FastSync {
-		m = downloader.FastSync
-	}
-	if eth.protocolManager, err = NewProtocolManager(eth.chainConfig, m, uint64(config.NetworkId), eth.eventMux, eth.txPool, eth.pow, eth.blockchain, chainDb); err != nil {
+	if eth.protocolManager, err = NewProtocolManager(eth.chainConfig, config.SyncMode, uint64(config.NetworkId), eth.eventMux, eth.txPool, eth.pow, eth.blockchain, chainDb); err != nil {
 		return nil, err
 	}
 	eth.miner = miner.New(eth, eth.chainConfig, eth.EventMux(), eth.pow)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -118,14 +118,15 @@ func ErrWasRequested(e error) bool {
 type SyncMode int
 
 const (
-	FullSync  SyncMode = iota // Synchronise the entire blockchain history from full blocks
-	FastSync                  // Quickly download the headers, full sync only at the chain head
-	LightSync                 // Download only the headers and terminate afterwards
+	FullSync      SyncMode = iota // Synchronise the entire blockchain history from full blocks
+	ForceFullSync                 // Like above, but ensure FullSync no matter the DB state
+	FastSync                      // Quickly download the headers, full sync only at the chain head
+	LightSync                     // Download only the headers and terminate afterwards
 )
 
 func (m SyncMode) String() string {
 	switch m {
-	case FullSync:
+	case FullSync, ForceFullSync:
 		return "FULL"
 	case FastSync:
 		return "FAST"

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -112,10 +112,25 @@ func NewProtocolManager(config *core.ChainConfig, mode downloader.SyncMode, netw
 		txsyncCh:    make(chan *txsync),
 		quitSync:    make(chan struct{}),
 	}
+
 	// Figure out whether to allow fast sync or not
 	if mode == downloader.FastSync && blockchain.CurrentBlock().NumberU64() > 0 {
 		glog.V(logger.Warn).Infoln("Blockchain not empty, fast sync disabled")
 		glog.D(logger.Warn).Warnln("Blockchain not empty. Fast sync disabled.")
+		mode = downloader.FullSync
+	}
+	// ForceFullSync is used only here to ensure that fast sync is not enabled
+	if mode != downloader.ForceFullSync && blockchain.CurrentBlock().NumberU64() == 0 && blockchain.CurrentFastBlock().NumberU64() > 0 {
+		// The database seems empty as the current block is the genesis. Yet the fast
+		// block is ahead, so fast sync was enabled for this node at a certain point.
+		// The only scenario where this can happen is if the user manually (or via a
+		// bad block) rolled back a fast sync node below the sync point. In this case
+		// however it's safe to reenable fast sync.
+		atomic.StoreUint32(&manager.fastSync, 1)
+		mode = downloader.FastSync
+	}
+	// Forced full sync, is actually "normal" full sync
+	if mode == downloader.ForceFullSync {
 		mode = downloader.FullSync
 	}
 	if mode == downloader.FastSync {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -185,14 +185,6 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		// Fast sync was explicitly requested, and explicitly granted
 		mode = downloader.FastSync
-	} else if currentBlock.NumberU64() == 0 && pm.blockchain.CurrentFastBlock().NumberU64() > 0 {
-		// The database seems empty as the current block is the genesis. Yet the fast
-		// block is ahead, so fast sync was enabled for this node at a certain point.
-		// The only scenario where this can happen is if the user manually (or via a
-		// bad block) rolled back a fast sync node below the sync point. In this case
-		// however it's safe to reenable fast sync.
-		atomic.StoreUint32(&pm.fastSync, 1)
-		mode = downloader.FastSync
 	}
 
 	if mode == downloader.FastSync {


### PR DESCRIPTION
Added `--slow` option, that forces full sync, even if `--fast` is
specified or fast sync is in process (only fast blocks stored in DB).

This also changes the place where the "auto continuation" of fast sync
is detected/enabled.