### PR TITLE
WIP: Add Dockerfile for autobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build Geth in a stock Go builder container
+FROM golang:1.11-alpine as builder
+
+RUN apk add --no-cache bash git make gcc musl-dev linux-headers
+
+RUN go get -v github.com/ethereumproject/go-ethereum/...
+RUN go install github.com/ethereumproject/go-ethereum/cmd/geth
+RUN cp -R ./bin /usr/local/bin/
+
+EXPOSE 8545:8546 30303:30303/udp
+ENTRYPOINT ["geth"]
+


### PR DESCRIPTION
Adds:

# Build Geth in a stock Go builder container
FROM golang:1.11-alpine as builder

RUN apk add --no-cache bash git make gcc musl-dev linux-headers

RUN go get -v github.com/ethereumproject/go-ethereum/...
RUN go install github.com/ethereumproject/go-ethereum/cmd/geth
RUN cp -R ./bin /usr/local/bin/

EXPOSE 8545:8546 30303:30303/udp
ENTRYPOINT ["geth"]

So hub.docker.com/r/ethereumclassic can do auto builds of geth