### PR TITLE
Add height in rpc getwork

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -217,7 +217,8 @@ func (s *PublicMinerAPI) SubmitWork(nonce rpc.HexNumber, solution, digest common
 // result[0], 32 bytes hex encoded current block header pow-hash
 // result[1], 32 bytes hex encoded seed hash used for DAG
 // result[2], 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
-func (s *PublicMinerAPI) GetWork() (work [3]string, err error) {
+// result[3], height in decimal
+func (s *PublicMinerAPI) GetWork() (work [4]string, err error) {
 	if !s.e.IsMining() {
 		if err := s.e.StartMining(0, ""); err != nil {
 			return work, err

--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereumproject/go-ethereum/common"
 	"github.com/ethereumproject/go-ethereum/logger"
 	"github.com/ethereumproject/go-ethereum/logger/glog"
+	"github.com/ethereumproject/go-ethereum/rpc"
 )
 
 type hashrate struct {
@@ -103,11 +104,11 @@ func (a *RemoteAgent) GetHashRate() (tot int64) {
 	return
 }
 
-func (a *RemoteAgent) GetWork() ([3]string, error) {
+func (a *RemoteAgent) GetWork() ([4]string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	var res [3]string
+	var res [4]string
 
 	if a.currentWork != nil {
 		block := a.currentWork.Block
@@ -121,6 +122,7 @@ func (a *RemoteAgent) GetWork() ([3]string, error) {
 		n.Div(n, block.Difficulty())
 		n.Lsh(n, 1)
 		res[2] = common.BytesToHash(n.Bytes()).Hex()
+		res[3] = rpc.NewHexNumber(block.Number()).BigInt().String()
 
 		a.work[block.HashNoNonce()] = a.currentWork
 		return res, nil


### PR DESCRIPTION
When miners/stratums want to get new block template, they have to use rpc request twice.
- 'eth_getBlockByNumber' for height
- 'eth_getWork' for pow informations

After receiving result of 'eth_getWork', the real blockNumber right now may be different to the response of 'eth_getBlockByNumber'.
Just call rpc once and get the complete informations.



